### PR TITLE
fix(ui): fix navbar UI bugs

### DIFF
--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -11,6 +11,7 @@ import {
   ListItem,
   ListItemText,
   ListItemIcon,
+  useMediaQuery,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { NavLink, useNavigate } from "react-router-dom";
@@ -35,6 +36,7 @@ const Navbar = ({ theme, onThemeToggle, onLogout }) => {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const navigate = useNavigate();
+  const isLargeScreen = useMediaQuery("(min-width:1111px)");
 
   useEffect(() => {
     const checkLoggedInStatus = () => {
@@ -238,7 +240,7 @@ const Navbar = ({ theme, onThemeToggle, onLogout }) => {
           DocuThinker
         </Typography>
 
-        <Box sx={{ display: { xs: "none", md: "flex" } }}>{renderNavLinks}</Box>
+        <Box sx={{ display: isLargeScreen ? "flex" : "none" }}>{renderNavLinks}</Box>
 
         <IconButton
           onClick={onThemeToggle}
@@ -258,7 +260,7 @@ const Navbar = ({ theme, onThemeToggle, onLogout }) => {
           edge="start"
           color="inherit"
           aria-label="menu"
-          sx={{ display: { xs: "flex", md: "none", marginLeft: "4px" } }}
+          sx={{ display: isLargeScreen ? "none" : "flex", marginLeft: "4px" }}
           onClick={toggleDrawer(true)}
         >
           <MenuIcon sx={{ color: theme === "dark" ? "white" : "black" }} />

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -240,7 +240,9 @@ const Navbar = ({ theme, onThemeToggle, onLogout }) => {
           DocuThinker
         </Typography>
 
-        <Box sx={{ display: isLargeScreen ? "flex" : "none" }}>{renderNavLinks}</Box>
+        <Box sx={{ display: isLargeScreen ? "flex" : "none" }}>
+          {renderNavLinks}
+        </Box>
 
         <IconButton
           onClick={onThemeToggle}


### PR DESCRIPTION
This pull request updates the navigation bar's responsive behavior in `frontend/src/components/Navbar.js` by switching from Material UI's breakpoint-based display logic to a custom media query for screen width. This change allows for more granular control over when navigation links and the menu icon are shown, specifically targeting screens wider than 1111px.

Responsive display improvements:

* Added `useMediaQuery` from Material UI and implemented `isLargeScreen` to determine if the screen width is at least 1111px. [[1]](diffhunk://#diff-8cb5d405d8282c837aea539b0220efbd732cc02d53b5f5553a7875221f968ed2R14) [[2]](diffhunk://#diff-8cb5d405d8282c837aea539b0220efbd732cc02d53b5f5553a7875221f968ed2R39)
* Updated the display logic for navigation links and the menu icon to use `isLargeScreen`, showing links only on large screens and the menu icon only on smaller screens. [[1]](diffhunk://#diff-8cb5d405d8282c837aea539b0220efbd732cc02d53b5f5553a7875221f968ed2L241-R245) [[2]](diffhunk://#diff-8cb5d405d8282c837aea539b0220efbd732cc02d53b5f5553a7875221f968ed2L261-R265)