### PR TITLE
feat(auth): add passkey (WebAuthn) support with management UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,21 @@ FIREBASE_CLIENT_X509_CERT_URL
 # JWT Secret
 JWT_SECRET
 
+# Passkeys / WebAuthn (optional — the backend derives sensible defaults from the
+# request Origin when these are unset). Pin them for production / custom domains:
+#   WEBAUTHN_RP_ID   : Relying Party ID = the site's registrable domain
+#                      (e.g. "docuthinker-fullstack-app.vercel.app")
+#   WEBAUTHN_ORIGINS : comma-separated allowlist of full frontend origins
+#                      (e.g. "https://docuthinker-fullstack-app.vercel.app")
+#   WEBAUTHN_RP_NAME : human-readable app name shown in the passkey prompt
+WEBAUTHN_RP_ID
+WEBAUTHN_ORIGINS
+WEBAUTHN_RP_NAME
+
+# Frontend: override the backend API origin at build time (optional).
+# Defaults to the deployed backend when unset.
+REACT_APP_API_BASE_URL
+
 # Redis Configuration
 REDIS_URL
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,6 +40,7 @@ DocuThinker is an **enterprise-grade**, full-stack AI-powered document analysis 
 - **Content Rewriting**: Style-based content transformation
 - **Semantic Search**: Vector-based document search using embeddings
 - **User Management**: Firebase Authentication with social login options
+- **Passkeys (WebAuthn)**: Passwordless, phishing-resistant sign-in; multiple credentials per user, managed from a dedicated Passkeys page. A successful assertion mints a Firebase custom token, so passkeys plug into the existing session model unchanged
 - **Cloud-Native Architecture**: Kubernetes-based deployment with microservices
 - **Observability**: Full-stack monitoring with OpenTelemetry, Prometheus, Grafana, Jaeger, and Coralogix
 - **Security**: mTLS, OPA policy enforcement, runtime security with Falco, SonarQube code quality gates, Snyk vulnerability management
@@ -504,9 +505,57 @@ classDiagram
         +Date lastAccess
     }
 
+    class Passkey {
+        +String credentialId
+        +String userId
+        +String publicKey
+        +Number counter
+        +Array transports
+        +String deviceType
+        +Boolean backedUp
+        +String name
+        +Date createdAt
+        +Date lastUsedAt
+    }
+
     User "1" --> "*" Document : has
     User "1" --> "1" Analytics : has
+    User "1" --> "*" Passkey : has
 ```
+
+#### Passkey (WebAuthn) Authentication
+
+Passwordless sign-in is implemented with `@simplewebauthn/server` (`controllers/passkeyController.js`,
+`models/passkeyModel.js`) and stored in two Firestore collections:
+
+- `passkeys/{credentialId}` — one document per credential, linked to the account via `userId` (a user may own many).
+- `webauthnChallenges/{flowId}` — short-lived (5-minute TTL) registration/authentication challenges, consumed once.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant FE as Frontend (@simplewebauthn/browser)
+    participant BE as Backend (@simplewebauthn/server)
+    participant FS as Firestore
+    participant FB as Firebase Auth
+
+    User->>FE: Click "Sign in with a passkey"
+    FE->>BE: POST /passkey/authenticate/options
+    BE->>FS: store challenge {flowId}
+    BE-->>FE: options + flowId
+    FE->>User: OS passkey prompt (biometric / PIN)
+    User-->>FE: assertion
+    FE->>BE: POST /passkey/authenticate/verify {flowId, response}
+    BE->>FS: load challenge + credential, verify, bump counter
+    BE->>FB: createCustomToken(userId)
+    BE-->>FE: { customToken, userId }
+    FE->>FE: setAuth(customToken, userId)
+```
+
+The Relying Party ID / expected origin default to the request `Origin` and can be pinned via
+`WEBAUTHN_RP_ID` / `WEBAUTHN_ORIGINS` / `WEBAUTHN_RP_NAME`. Because verification returns the same
+`{ customToken, userId }` as `/login`, passkeys reuse the existing client session model verbatim.
 
 ---
 
@@ -1868,6 +1917,7 @@ graph TB
     subgraph "Layer 3: Authentication"
         FIREBASE[Firebase Auth]
         JWT[JWT Tokens]
+        WEBAUTHN[Passkeys / WebAuthn<br/>Phishing-resistant]
         RBAC[Kubernetes RBAC]
     end
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ We have deployed the entire app on **Vercel** and **AWS**. You can access the li
 - **Document Analytics**: View interactive and charts-powered analytics such as word count, reading time, sentiment distribution, and more!
 - **Profile Management**: Update your profile information, social media links, and theme settings.
 - **User Authentication**: Secure registration, login, and password reset functionality.
+- **Passwordless Sign-In (Passkeys / WebAuthn)**: Register multiple passkeys and sign in with your fingerprint, face, or device PIN — no password required. A post-sign-up prompt invites users to enroll, and a dedicated **Passkeys** page lets them add, rename, and delete keys.
 - **Document History**: View all uploaded documents and their details.
 - **Mobile App Integration**: React Native mobile app for on-the-go document management.
 - **Dark Mode Support**: Toggle between light and dark themes for better accessibility.
@@ -731,12 +732,14 @@ DocuThinker-AI-App/
 │   ├── middleware/
 │   │   └── jwt.js                    # Authentication middleware with JWT for the app's backend
 │   ├── controllers/
-│   │   └── controllers.js            # Controls the flow of data and logic
+│   │   ├── controllers.js            # Controls the flow of data and logic
+│   │   └── passkeyController.js      # Passkey (WebAuthn) ceremony + endpoints
 │   ├── graphql/
 │   │   ├── resolvers.js              # Resolvers for querying data from the database
 │   │   └── schema.js                 # GraphQL schema for querying data from the database
 │   ├── models/
-│   │   └── models.js                 # Data models for interacting with the database
+│   │   ├── models.js                 # Data models for interacting with the database
+│   │   └── passkeyModel.js           # Firestore access for passkeys & challenges
 │   ├── services/
 │   │   └── services.js               # Models for interacting with database and AI/ML services
 │   ├── views/
@@ -1010,6 +1013,13 @@ The backend of **DocuThinker** provides several API endpoints for user authentic
 |------------|--------------------------------------|-----------------------------------------------------------------------------------------------------|
 | POST       | `/register`                          | Register a new user in Firebase Authentication and Firestore, saving their email and creation date. |
 | POST       | `/login`                             | Log in a user and return a custom token along with the user ID.                                     |
+| POST       | `/passkey/register/options`          | Begin passkey registration; returns WebAuthn creation options + a `flowId`.                         |
+| POST       | `/passkey/register/verify`           | Verify the authenticator attestation and store the new passkey credential.                          |
+| POST       | `/passkey/authenticate/options`      | Begin passkey login (email-scoped or discoverable/usernameless); returns options + `flowId`.        |
+| POST       | `/passkey/authenticate/verify`       | Verify the assertion and return a Firebase custom token + user ID (same contract as `/login`).      |
+| GET        | `/passkeys/{userId}`                 | List all passkeys registered to a user (public metadata only).                                      |
+| PATCH      | `/passkeys/{userId}/{credentialId}`  | Rename one of the user's passkeys.                                                                  |
+| DELETE     | `/passkeys/{userId}/{credentialId}`  | Delete one of the user's passkeys.                                                                 |
 | POST       | `/upload`                            | Upload a document for summarization. If the user is logged in, the document is saved in Firestore.  |
 | POST       | `/generate-key-ideas`                | Generate key ideas from the document text.                                                          |
 | POST       | `/generate-discussion-points`        | Generate discussion points from the document text.                                                  |

--- a/backend/README.md
+++ b/backend/README.md
@@ -21,6 +21,7 @@ The backend is currently hosted on Render and can be accessed at [https://docuth
 ## Features
 
 - **User Registration & Authentication**: Using Firebase for authentication.
+- **Passkeys / WebAuthn**: Passwordless, phishing-resistant sign-in via `@simplewebauthn/server`. Supports multiple credentials per user and a usernameless (discoverable) login flow; a successful assertion mints a Firebase custom token, matching the `/login` contract.
 - **Document Upload & Summarization**: Supports PDF and Word documents.
 - **AI-Driven Key Ideas & Discussion Points**: Google Generative AI.
 - **Password Reset Functionality**: Email-based password reset.
@@ -74,6 +75,12 @@ FIREBASE_CLIENT_X509_CERT_URL=https://www.googleapis.com/robot/v1/metadata/x509/
 
 GOOGLE_AI_API_KEY=your-google-generative-ai-api-key
 FIREBASE_DATABASE_URL=https://your-project-id.firebaseio.com
+
+# Passkeys / WebAuthn (optional — defaults are derived from the request Origin).
+# Pin these for production / custom domains:
+WEBAUTHN_RP_ID=docuthinker-fullstack-app.vercel.app
+WEBAUTHN_ORIGINS=https://docuthinker-fullstack-app.vercel.app
+WEBAUTHN_RP_NAME=DocuThinker
 ```
 
 Make sure to replace these values with your Firebase and Google Generative AI credentials.
@@ -135,6 +142,13 @@ The backend of **DocuThinker** provides the following API endpoints:
 | ---------- | ------------------------------------ | --------------------------------------------------------------------------------------------------- |
 | POST       | `/register`                          | Register a new user in Firebase Authentication and Firestore, saving their email and creation date. |
 | POST       | `/login`                             | Log in a user and return a custom token along with the user ID.                                     |
+| POST       | `/passkey/register/options`          | Begin passkey registration; returns WebAuthn creation options + a `flowId`.                         |
+| POST       | `/passkey/register/verify`           | Verify the authenticator attestation and store the new passkey credential.                          |
+| POST       | `/passkey/authenticate/options`      | Begin passkey login (email-scoped or discoverable); returns options + `flowId`.                     |
+| POST       | `/passkey/authenticate/verify`       | Verify the assertion and return a Firebase custom token + user ID (same contract as `/login`).      |
+| GET        | `/passkeys/{userId}`                 | List all passkeys registered to a user (public metadata only).                                      |
+| PATCH      | `/passkeys/{userId}/{credentialId}`  | Rename one of the user's passkeys.                                                                  |
+| DELETE     | `/passkeys/{userId}/{credentialId}`  | Delete one of the user's passkeys.                                                                 |
 | POST       | `/upload`                            | Upload a document for summarization. If the user is logged in, the document is saved in Firestore.  |
 | POST       | `/generate-key-ideas`                | Generate key ideas from the document text.                                                          |
 | POST       | `/generate-discussion-points`        | Generate discussion points from the document text.                                                  |
@@ -161,6 +175,32 @@ Example:
 ```bash
 Authorization: Bearer <your-jwt-token>
 ```
+
+### Passkeys (WebAuthn)
+
+Passwordless sign-in is implemented with [`@simplewebauthn/server`](https://simplewebauthn.dev/) and lives in
+`controllers/passkeyController.js` (HTTP + ceremony logic) and `models/passkeyModel.js` (Firestore access).
+
+**Data model (Firestore):**
+
+- `passkeys/{credentialId}` — one document per credential: `userId`, `publicKey` (base64url), `counter`,
+  `transports`, `deviceType`, `backedUp`, `aaguid`, `name`, `createdAt`, `lastUsedAt`. A user may own many.
+- `webauthnChallenges/{flowId}` — short-lived (5-minute TTL) registration/authentication challenges, deleted as
+  soon as they are consumed.
+
+**Ceremonies:**
+
+1. **Register** — `POST /passkey/register/options` (returns options + `flowId`, excluding already-enrolled
+   credentials) → browser creates the credential → `POST /passkey/register/verify` validates the attestation and
+   stores it.
+2. **Authenticate** — `POST /passkey/authenticate/options` (email-scoped or discoverable) → browser produces an
+   assertion → `POST /passkey/authenticate/verify` validates it, bumps the signature counter (clone detection),
+   and returns a **Firebase custom token + `userId`** — the same shape as `/login`, so the client's auth flow is
+   identical for password and passkey sign-in.
+
+**Configuration:** the Relying Party ID and expected origin are derived from the request `Origin` header by
+default, and can be pinned for production via `WEBAUTHN_RP_ID`, `WEBAUTHN_ORIGINS`, and `WEBAUTHN_RP_NAME` (see
+[Environment Variables](#environment-variables)).
 
 ### Testing the API
 
@@ -190,7 +230,7 @@ curl --location --request POST 'http://localhost:3000/upload' \
 The backend of DocuThinker comes with self-documenting APIs using **Swagger**.
 
 - You can interact with the APIs at `http://localhost:3000/api-docs`.
-- This Swagger documentation is automatically generated from the JSDoc comments in `index.js` and `controllers.js`.
+- This Swagger documentation is automatically generated from the JSDoc comments in `index.js`, `controllers/controllers.js`, `controllers/passkeyController.js`, and `models/models.js`.
 
 ### Authorization
 

--- a/backend/__tests__/passkeyController.test.js
+++ b/backend/__tests__/passkeyController.test.js
@@ -1,0 +1,349 @@
+const mockAuth = {
+  getUser: jest.fn(),
+  getUserByEmail: jest.fn(),
+  createCustomToken: jest.fn(),
+};
+
+jest.mock("firebase-admin", () => ({
+  auth: () => mockAuth,
+}));
+
+jest.mock("../models/passkeyModel", () => ({
+  Passkey: {
+    create: jest.fn(),
+    getById: jest.fn(),
+    listByUser: jest.fn(),
+    updateCounter: jest.fn(),
+    rename: jest.fn(),
+    remove: jest.fn(),
+  },
+  Challenge: {
+    save: jest.fn(),
+    get: jest.fn(),
+    remove: jest.fn(),
+  },
+  toIso: (value) => (value ? new Date(value).toISOString() : null),
+}));
+
+jest.mock("../views/views", () => ({
+  sendSuccessResponse: jest.fn(),
+  sendErrorResponse: jest.fn(),
+}));
+
+jest.mock("@simplewebauthn/server", () => ({
+  generateRegistrationOptions: jest.fn(),
+  verifyRegistrationResponse: jest.fn(),
+  generateAuthenticationOptions: jest.fn(),
+  verifyAuthenticationResponse: jest.fn(),
+}));
+
+const controller = require("../controllers/passkeyController");
+const { Passkey, Challenge } = require("../models/passkeyModel");
+const { sendSuccessResponse, sendErrorResponse } = require("../views/views");
+const webauthn = require("@simplewebauthn/server");
+
+const makeReq = (overrides = {}) => ({
+  body: {},
+  params: {},
+  headers: {
+    origin: "https://app.example.com",
+    "user-agent": "Mozilla/5.0 (Macintosh) Chrome/120 Safari/537",
+  },
+  ...overrides,
+});
+
+const res = {};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("getRegistrationOptions", () => {
+  it("rejects when userId is missing", async () => {
+    await controller.getRegistrationOptions(makeReq({ body: {} }), res);
+    expect(sendErrorResponse).toHaveBeenCalledWith(res, 400, "userId is required");
+  });
+
+  it("returns 404 when the user does not exist", async () => {
+    mockAuth.getUser.mockRejectedValue(new Error("no user"));
+    await controller.getRegistrationOptions(
+      makeReq({ body: { userId: "u1" } }),
+      res,
+    );
+    expect(sendErrorResponse).toHaveBeenCalledWith(
+      res,
+      404,
+      "User not found",
+      "no user",
+    );
+  });
+
+  it("generates options, stores a challenge, and excludes existing keys", async () => {
+    mockAuth.getUser.mockResolvedValue({ email: "a@b.com", displayName: null });
+    Passkey.listByUser.mockResolvedValue([
+      { credentialId: "existing", transports: ["internal"] },
+    ]);
+    webauthn.generateRegistrationOptions.mockResolvedValue({
+      challenge: "CHALLENGE",
+    });
+
+    await controller.getRegistrationOptions(
+      makeReq({ body: { userId: "u1" } }),
+      res,
+    );
+
+    expect(webauthn.generateRegistrationOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rpID: "app.example.com",
+        excludeCredentials: [
+          { id: "existing", transports: ["internal"] },
+        ],
+      }),
+    );
+    expect(Challenge.save).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        challenge: "CHALLENGE",
+        type: "registration",
+        userId: "u1",
+        rpID: "app.example.com",
+        origin: "https://app.example.com",
+      }),
+    );
+    expect(sendSuccessResponse).toHaveBeenCalledWith(
+      res,
+      200,
+      "Registration options generated",
+      expect.objectContaining({ options: { challenge: "CHALLENGE" } }),
+    );
+  });
+});
+
+describe("verifyRegistration", () => {
+  it("rejects a mismatched challenge session", async () => {
+    Challenge.get.mockResolvedValue({ type: "registration", userId: "other" });
+    await controller.verifyRegistration(
+      makeReq({ body: { userId: "u1", flowId: "f1", response: {} } }),
+      res,
+    );
+    expect(sendErrorResponse).toHaveBeenCalledWith(
+      res,
+      400,
+      "Invalid or expired registration session",
+    );
+  });
+
+  it("verifies attestation and stores the credential", async () => {
+    Challenge.get.mockResolvedValue({
+      type: "registration",
+      userId: "u1",
+      challenge: "CHALLENGE",
+      origin: "https://app.example.com",
+      rpID: "app.example.com",
+      createdAt: new Date(),
+    });
+    webauthn.verifyRegistrationResponse.mockResolvedValue({
+      verified: true,
+      registrationInfo: {
+        credential: {
+          id: "cred-1",
+          publicKey: new Uint8Array([9, 9]),
+          counter: 0,
+          transports: ["internal", "hybrid"],
+        },
+        credentialDeviceType: "multiDevice",
+        credentialBackedUp: true,
+        aaguid: "aaguid-1",
+      },
+    });
+    Passkey.getById.mockResolvedValue(null);
+
+    await controller.verifyRegistration(
+      makeReq({
+        body: {
+          userId: "u1",
+          flowId: "f1",
+          name: "My Laptop",
+          response: { id: "cred-1", response: {} },
+        },
+      }),
+      res,
+    );
+
+    expect(Passkey.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentialId: "cred-1",
+        userId: "u1",
+        publicKey: expect.any(String),
+        backedUp: true,
+        deviceType: "multiDevice",
+        name: "My Laptop",
+      }),
+    );
+    expect(Challenge.remove).toHaveBeenCalledWith("f1");
+    expect(sendSuccessResponse).toHaveBeenCalledWith(
+      res,
+      201,
+      "Passkey registered successfully",
+      expect.objectContaining({
+        passkey: expect.objectContaining({ id: "cred-1", name: "My Laptop" }),
+      }),
+    );
+  });
+
+  it("returns 409 when the credential already exists", async () => {
+    Challenge.get.mockResolvedValue({
+      type: "registration",
+      userId: "u1",
+      challenge: "CHALLENGE",
+      origin: "https://app.example.com",
+      rpID: "app.example.com",
+      createdAt: new Date(),
+    });
+    webauthn.verifyRegistrationResponse.mockResolvedValue({
+      verified: true,
+      registrationInfo: {
+        credential: { id: "dup", publicKey: new Uint8Array([1]), counter: 0 },
+        credentialDeviceType: "singleDevice",
+        credentialBackedUp: false,
+      },
+    });
+    Passkey.getById.mockResolvedValue({ credentialId: "dup" });
+
+    await controller.verifyRegistration(
+      makeReq({
+        body: { userId: "u1", flowId: "f1", response: { id: "dup" } },
+      }),
+      res,
+    );
+
+    expect(sendErrorResponse).toHaveBeenCalledWith(
+      res,
+      409,
+      "This passkey is already registered",
+    );
+    expect(Passkey.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("verifyAuthentication", () => {
+  it("rejects an unknown credential", async () => {
+    Challenge.get.mockResolvedValue({
+      type: "authentication",
+      challenge: "CHALLENGE",
+      origin: "https://app.example.com",
+      rpID: "app.example.com",
+      createdAt: new Date(),
+    });
+    Passkey.getById.mockResolvedValue(null);
+
+    await controller.verifyAuthentication(
+      makeReq({ body: { flowId: "f1", response: { id: "missing" } } }),
+      res,
+    );
+
+    expect(sendErrorResponse).toHaveBeenCalledWith(
+      res,
+      401,
+      "Passkey not recognized",
+    );
+  });
+
+  it("verifies the assertion and returns a custom token", async () => {
+    Challenge.get.mockResolvedValue({
+      type: "authentication",
+      challenge: "CHALLENGE",
+      origin: "https://app.example.com",
+      rpID: "app.example.com",
+      createdAt: new Date(),
+    });
+    Passkey.getById.mockResolvedValue({
+      credentialId: "cred-1",
+      userId: "u1",
+      publicKey: "PUBLIC_KEY_B64URL",
+      counter: 4,
+      transports: ["internal"],
+    });
+    webauthn.verifyAuthenticationResponse.mockResolvedValue({
+      verified: true,
+      authenticationInfo: { newCounter: 5 },
+    });
+    mockAuth.createCustomToken.mockResolvedValue("CUSTOM_TOKEN");
+    mockAuth.getUser.mockResolvedValue({ email: "a@b.com" });
+
+    await controller.verifyAuthentication(
+      makeReq({ body: { flowId: "f1", response: { id: "cred-1" } } }),
+      res,
+    );
+
+    expect(Passkey.updateCounter).toHaveBeenCalledWith("cred-1", 5);
+    expect(mockAuth.createCustomToken).toHaveBeenCalledWith("u1");
+    expect(sendSuccessResponse).toHaveBeenCalledWith(
+      res,
+      200,
+      "Authentication successful",
+      { customToken: "CUSTOM_TOKEN", userId: "u1", email: "a@b.com" },
+    );
+  });
+});
+
+describe("listPasskeys / renamePasskey / deletePasskey", () => {
+  it("lists serialized passkeys", async () => {
+    Passkey.listByUser.mockResolvedValue([
+      {
+        credentialId: "c1",
+        name: "Key 1",
+        deviceType: "multiDevice",
+        backedUp: true,
+        transports: ["internal"],
+        createdAt: new Date("2026-01-01"),
+        lastUsedAt: null,
+      },
+    ]);
+
+    await controller.listPasskeys(makeReq({ params: { userId: "u1" } }), res);
+
+    expect(sendSuccessResponse).toHaveBeenCalledWith(
+      res,
+      200,
+      "Passkeys retrieved",
+      expect.objectContaining({
+        passkeys: [expect.objectContaining({ id: "c1", name: "Key 1" })],
+      }),
+    );
+  });
+
+  it("returns 404 when renaming a passkey the user does not own", async () => {
+    Passkey.getById.mockResolvedValue({ userId: "someone-else" });
+    await controller.renamePasskey(
+      makeReq({ params: { userId: "u1", credentialId: "c1" }, body: { name: "X" } }),
+      res,
+    );
+    expect(sendErrorResponse).toHaveBeenCalledWith(res, 404, "Passkey not found");
+    expect(Passkey.rename).not.toHaveBeenCalled();
+  });
+
+  it("renames an owned passkey", async () => {
+    Passkey.getById.mockResolvedValue({ userId: "u1", credentialId: "c1" });
+    await controller.renamePasskey(
+      makeReq({
+        params: { userId: "u1", credentialId: "c1" },
+        body: { name: "  Work Laptop  " },
+      }),
+      res,
+    );
+    expect(Passkey.rename).toHaveBeenCalledWith("c1", "Work Laptop");
+  });
+
+  it("deletes an owned passkey", async () => {
+    Passkey.getById.mockResolvedValue({ userId: "u1", credentialId: "c1" });
+    await controller.deletePasskey(
+      makeReq({ params: { userId: "u1", credentialId: "c1" } }),
+      res,
+    );
+    expect(Passkey.remove).toHaveBeenCalledWith("c1");
+    expect(sendSuccessResponse).toHaveBeenCalledWith(res, 200, "Passkey deleted", {
+      id: "c1",
+    });
+  });
+});

--- a/backend/controllers/passkeyController.js
+++ b/backend/controllers/passkeyController.js
@@ -1,0 +1,654 @@
+const {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} = require("@simplewebauthn/server");
+const { v4: uuidv4 } = require("uuid");
+const firebaseAdmin = require("firebase-admin");
+const { Passkey, Challenge, toIso } = require("../models/passkeyModel");
+const { sendSuccessResponse, sendErrorResponse } = require("../views/views");
+
+// Challenges are valid for 5 minutes — long enough for the user to complete the
+// browser prompt, short enough to keep the replay window tiny.
+const CHALLENGE_TTL_MS = 5 * 60 * 1000;
+const MAX_PASSKEY_NAME_LENGTH = 60;
+const RP_NAME = process.env.WEBAUTHN_RP_NAME || "DocuThinker";
+
+/**
+ * Split a comma-separated env value into a trimmed, non-empty list.
+ * @param {string} value - Raw env value
+ * @returns {string[]} - Parsed list
+ */
+const parseList = (value) =>
+  (value || "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+// base64url <-> bytes helpers (Node's Buffer supports "base64url" on 18+).
+const bytesToBase64Url = (bytes) => Buffer.from(bytes).toString("base64url");
+const base64UrlToBytes = (value) =>
+  new Uint8Array(Buffer.from(value, "base64url"));
+const utf8ToBytes = (value) => new Uint8Array(Buffer.from(value, "utf8"));
+
+/**
+ * Resolve the Relying Party ID and the expected origin for a request.
+ *
+ * WebAuthn binds credentials to the origin of the page that created them, which
+ * the browser sends as the `Origin` header on the (cross-origin) API call. We
+ * therefore derive the RP from that header by default, and let operators pin it
+ * explicitly via env for custom domains:
+ *   - WEBAUTHN_RP_ID   : fixed RP ID (e.g. "docuthinker.vercel.app")
+ *   - WEBAUTHN_ORIGINS : comma-separated allowlist of full origins
+ *                        (falls back to FRONTEND_URL)
+ *
+ * @param {object} req - Express request
+ * @returns {{ rpID: string, origin: string, rpName: string }}
+ */
+const resolveRelyingParty = (req) => {
+  const originHeader = (req.headers && req.headers.origin) || "";
+  const allowedOrigins = parseList(
+    process.env.WEBAUTHN_ORIGINS || process.env.FRONTEND_URL,
+  );
+  const configuredRpId = process.env.WEBAUTHN_RP_ID || "";
+
+  let origin = "";
+  if (
+    originHeader &&
+    (allowedOrigins.length === 0 || allowedOrigins.includes(originHeader))
+  ) {
+    origin = originHeader;
+  } else if (allowedOrigins.length > 0) {
+    origin = allowedOrigins[0];
+  } else {
+    origin = "http://localhost:3000";
+  }
+
+  let rpID = configuredRpId;
+  if (!rpID) {
+    try {
+      rpID = new URL(origin).hostname;
+    } catch (error) {
+      rpID = "localhost";
+    }
+  }
+
+  return { rpID, origin, rpName: RP_NAME };
+};
+
+/**
+ * Whether a stored challenge is older than the allowed TTL.
+ * @param {*} createdAt - Firestore Timestamp / Date / string
+ * @returns {boolean}
+ */
+const isExpired = (createdAt) => {
+  const ms =
+    createdAt && typeof createdAt.toMillis === "function"
+      ? createdAt.toMillis()
+      : new Date(createdAt).getTime();
+  return !ms || Date.now() - ms > CHALLENGE_TTL_MS;
+};
+
+/**
+ * Build a friendly default passkey name from the request's User-Agent.
+ * @param {object} req - Express request
+ * @returns {string}
+ */
+const defaultPasskeyName = (req) => {
+  const ua = (req.headers && req.headers["user-agent"]) || "";
+  let device = "device";
+  if (/iphone|ipad|ipod/i.test(ua)) device = "iOS device";
+  else if (/android/i.test(ua)) device = "Android device";
+  else if (/mac os x|macintosh/i.test(ua)) device = "Mac";
+  else if (/windows/i.test(ua)) device = "Windows PC";
+  else if (/cros/i.test(ua)) device = "Chromebook";
+  else if (/linux/i.test(ua)) device = "Linux device";
+
+  let browser = "";
+  if (/edg\//i.test(ua)) browser = "Edge";
+  else if (/opr\/|opera/i.test(ua)) browser = "Opera";
+  else if (/firefox\//i.test(ua)) browser = "Firefox";
+  else if (/chrome\//i.test(ua)) browser = "Chrome";
+  else if (/safari\//i.test(ua)) browser = "Safari";
+
+  return browser ? `${browser} on ${device}` : `Passkey (${device})`;
+};
+
+/**
+ * Shape a stored passkey for API responses (never leaks the public key).
+ * @param {object} passkey - Stored passkey document
+ * @returns {object} - Safe, client-facing representation
+ */
+const serializePasskey = (passkey) => ({
+  id: passkey.credentialId,
+  name: passkey.name || "Passkey",
+  deviceType: passkey.deviceType || "singleDevice",
+  backedUp: !!passkey.backedUp,
+  transports: passkey.transports || [],
+  createdAt: toIso(passkey.createdAt),
+  lastUsedAt: toIso(passkey.lastUsedAt),
+});
+
+/**
+ * @swagger
+ * tags:
+ *   name: Passkeys
+ *   description: Passwordless authentication with WebAuthn passkeys.
+ */
+
+/**
+ * @swagger
+ * /passkey/register/options:
+ *   post:
+ *     summary: Begin passkey registration
+ *     description: >
+ *       Generate WebAuthn registration options (a challenge) for the signed-in
+ *       user. Already-registered credentials are excluded so the same
+ *       authenticator cannot be enrolled twice.
+ *     tags: [Passkeys]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               userId:
+ *                 type: string
+ *                 example: "abc123"
+ *     responses:
+ *       200:
+ *         description: Registration options generated
+ *       404:
+ *         description: User not found
+ */
+exports.getRegistrationOptions = async (req, res) => {
+  try {
+    const { userId } = req.body || {};
+    if (!userId) return sendErrorResponse(res, 400, "userId is required");
+
+    let userRecord;
+    try {
+      userRecord = await firebaseAdmin.auth().getUser(userId);
+    } catch (error) {
+      return sendErrorResponse(res, 404, "User not found", error.message);
+    }
+
+    const { rpID, rpName, origin } = resolveRelyingParty(req);
+    const existing = await Passkey.listByUser(userId);
+
+    const options = await generateRegistrationOptions({
+      rpName,
+      rpID,
+      userID: utf8ToBytes(userId),
+      userName: userRecord.email || userId,
+      userDisplayName:
+        userRecord.displayName || userRecord.email || "DocuThinker User",
+      attestationType: "none",
+      excludeCredentials: existing.map((passkey) => ({
+        id: passkey.credentialId,
+        transports: passkey.transports || undefined,
+      })),
+      authenticatorSelection: {
+        residentKey: "preferred",
+        userVerification: "preferred",
+      },
+    });
+
+    const flowId = uuidv4();
+    await Challenge.save(flowId, {
+      challenge: options.challenge,
+      type: "registration",
+      userId,
+      rpID,
+      origin,
+    });
+
+    sendSuccessResponse(res, 200, "Registration options generated", {
+      flowId,
+      options,
+    });
+  } catch (error) {
+    sendErrorResponse(
+      res,
+      500,
+      "Failed to create registration options",
+      error.message,
+    );
+  }
+};
+
+/**
+ * @swagger
+ * /passkey/register/verify:
+ *   post:
+ *     summary: Complete passkey registration
+ *     description: Verify the authenticator's attestation and store the credential.
+ *     tags: [Passkeys]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               flowId:
+ *                 type: string
+ *               name:
+ *                 type: string
+ *               response:
+ *                 type: object
+ *                 description: The RegistrationResponseJSON from the browser.
+ *     responses:
+ *       201:
+ *         description: Passkey registered successfully
+ *       400:
+ *         description: Verification failed or session expired
+ *       409:
+ *         description: Passkey already registered
+ */
+exports.verifyRegistration = async (req, res) => {
+  try {
+    const { userId, flowId, response, name } = req.body || {};
+    if (!userId || !flowId || !response) {
+      return sendErrorResponse(
+        res,
+        400,
+        "userId, flowId, and response are required",
+      );
+    }
+
+    const challenge = await Challenge.get(flowId);
+    if (
+      !challenge ||
+      challenge.type !== "registration" ||
+      challenge.userId !== userId
+    ) {
+      return sendErrorResponse(
+        res,
+        400,
+        "Invalid or expired registration session",
+      );
+    }
+    if (isExpired(challenge.createdAt)) {
+      await Challenge.remove(flowId);
+      return sendErrorResponse(res, 400, "Registration session expired");
+    }
+
+    let verification;
+    try {
+      verification = await verifyRegistrationResponse({
+        response,
+        expectedChallenge: challenge.challenge,
+        expectedOrigin: challenge.origin,
+        expectedRPID: challenge.rpID,
+        requireUserVerification: false,
+      });
+    } catch (error) {
+      await Challenge.remove(flowId);
+      return sendErrorResponse(
+        res,
+        400,
+        "Passkey registration verification failed",
+        error.message,
+      );
+    }
+
+    await Challenge.remove(flowId);
+
+    if (!verification.verified || !verification.registrationInfo) {
+      return sendErrorResponse(res, 400, "Passkey could not be verified");
+    }
+
+    const { credential, credentialDeviceType, credentialBackedUp, aaguid } =
+      verification.registrationInfo;
+
+    const alreadyRegistered = await Passkey.getById(credential.id);
+    if (alreadyRegistered) {
+      return sendErrorResponse(res, 409, "This passkey is already registered");
+    }
+
+    const passkey = {
+      credentialId: credential.id,
+      userId,
+      publicKey: bytesToBase64Url(credential.publicKey),
+      counter: credential.counter || 0,
+      transports:
+        credential.transports || (response.response || {}).transports || [],
+      deviceType: credentialDeviceType || "singleDevice",
+      backedUp: !!credentialBackedUp,
+      aaguid: aaguid || null,
+      name: (name && String(name).trim().slice(0, MAX_PASSKEY_NAME_LENGTH)) ||
+        defaultPasskeyName(req),
+      createdAt: new Date(),
+      lastUsedAt: null,
+    };
+    await Passkey.create(passkey);
+
+    sendSuccessResponse(res, 201, "Passkey registered successfully", {
+      passkey: serializePasskey(passkey),
+    });
+  } catch (error) {
+    sendErrorResponse(res, 500, "Failed to register passkey", error.message);
+  }
+};
+
+/**
+ * @swagger
+ * /passkey/authenticate/options:
+ *   post:
+ *     summary: Begin passkey authentication
+ *     description: >
+ *       Generate WebAuthn authentication options. If an email is supplied the
+ *       options are scoped to that account's credentials; otherwise a
+ *       discoverable-credential (usernameless) flow is used.
+ *     tags: [Passkeys]
+ *     requestBody:
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Authentication options generated
+ */
+exports.getAuthenticationOptions = async (req, res) => {
+  try {
+    const { email } = req.body || {};
+    const { rpID, origin } = resolveRelyingParty(req);
+
+    let allowCredentials = [];
+    if (email) {
+      try {
+        const userRecord = await firebaseAdmin.auth().getUserByEmail(email);
+        const passkeys = await Passkey.listByUser(userRecord.uid);
+        allowCredentials = passkeys.map((passkey) => ({
+          id: passkey.credentialId,
+          transports: passkey.transports || undefined,
+        }));
+      } catch (error) {
+        // Never reveal whether an email is registered: fall back to a
+        // discoverable-credential flow instead of erroring out.
+        allowCredentials = [];
+      }
+    }
+
+    const options = await generateAuthenticationOptions({
+      rpID,
+      allowCredentials,
+      userVerification: "preferred",
+    });
+
+    const flowId = uuidv4();
+    await Challenge.save(flowId, {
+      challenge: options.challenge,
+      type: "authentication",
+      rpID,
+      origin,
+    });
+
+    sendSuccessResponse(res, 200, "Authentication options generated", {
+      flowId,
+      options,
+    });
+  } catch (error) {
+    sendErrorResponse(
+      res,
+      500,
+      "Failed to create authentication options",
+      error.message,
+    );
+  }
+};
+
+/**
+ * @swagger
+ * /passkey/authenticate/verify:
+ *   post:
+ *     summary: Complete passkey authentication
+ *     description: >
+ *       Verify the authenticator assertion and, on success, return a Firebase
+ *       custom token and user ID — the same contract as the password `/login`
+ *       endpoint.
+ *     tags: [Passkeys]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               flowId:
+ *                 type: string
+ *               response:
+ *                 type: object
+ *                 description: The AuthenticationResponseJSON from the browser.
+ *     responses:
+ *       200:
+ *         description: Authentication successful
+ *       401:
+ *         description: Passkey not recognized or verification failed
+ */
+exports.verifyAuthentication = async (req, res) => {
+  try {
+    const { flowId, response } = req.body || {};
+    if (!flowId || !response) {
+      return sendErrorResponse(res, 400, "flowId and response are required");
+    }
+
+    const challenge = await Challenge.get(flowId);
+    if (!challenge || challenge.type !== "authentication") {
+      return sendErrorResponse(
+        res,
+        400,
+        "Invalid or expired authentication session",
+      );
+    }
+    if (isExpired(challenge.createdAt)) {
+      await Challenge.remove(flowId);
+      return sendErrorResponse(res, 400, "Authentication session expired");
+    }
+
+    const passkey = await Passkey.getById(response.id);
+    if (!passkey) {
+      await Challenge.remove(flowId);
+      return sendErrorResponse(res, 401, "Passkey not recognized");
+    }
+
+    let verification;
+    try {
+      verification = await verifyAuthenticationResponse({
+        response,
+        expectedChallenge: challenge.challenge,
+        expectedOrigin: challenge.origin,
+        expectedRPID: challenge.rpID,
+        credential: {
+          id: passkey.credentialId,
+          publicKey: base64UrlToBytes(passkey.publicKey),
+          counter: passkey.counter || 0,
+          transports: passkey.transports || undefined,
+        },
+        requireUserVerification: false,
+      });
+    } catch (error) {
+      await Challenge.remove(flowId);
+      return sendErrorResponse(
+        res,
+        401,
+        "Passkey authentication failed",
+        error.message,
+      );
+    }
+
+    await Challenge.remove(flowId);
+
+    if (!verification.verified) {
+      return sendErrorResponse(res, 401, "Passkey authentication failed");
+    }
+
+    await Passkey.updateCounter(
+      passkey.credentialId,
+      verification.authenticationInfo.newCounter,
+    );
+
+    // Mirror the /login response so the client's setAuth(token, userId) flow is
+    // identical for password and passkey sign-in.
+    const customToken = await firebaseAdmin
+      .auth()
+      .createCustomToken(passkey.userId);
+    let email = null;
+    try {
+      const userRecord = await firebaseAdmin.auth().getUser(passkey.userId);
+      email = userRecord.email || null;
+    } catch (error) {
+      email = null;
+    }
+
+    sendSuccessResponse(res, 200, "Authentication successful", {
+      customToken,
+      userId: passkey.userId,
+      email,
+    });
+  } catch (error) {
+    sendErrorResponse(
+      res,
+      500,
+      "Failed to authenticate with passkey",
+      error.message,
+    );
+  }
+};
+
+/**
+ * @swagger
+ * /passkeys/{userId}:
+ *   get:
+ *     summary: List a user's passkeys
+ *     tags: [Passkeys]
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Passkeys retrieved
+ */
+exports.listPasskeys = async (req, res) => {
+  try {
+    const { userId } = req.params;
+    if (!userId) return sendErrorResponse(res, 400, "userId is required");
+
+    const passkeys = await Passkey.listByUser(userId);
+    const serialized = passkeys
+      .map(serializePasskey)
+      .sort((a, b) => (b.createdAt || "").localeCompare(a.createdAt || ""));
+
+    sendSuccessResponse(res, 200, "Passkeys retrieved", {
+      passkeys: serialized,
+    });
+  } catch (error) {
+    sendErrorResponse(res, 500, "Failed to retrieve passkeys", error.message);
+  }
+};
+
+/**
+ * @swagger
+ * /passkeys/{userId}/{credentialId}:
+ *   patch:
+ *     summary: Rename a passkey
+ *     tags: [Passkeys]
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: credentialId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Passkey renamed
+ *       404:
+ *         description: Passkey not found
+ */
+exports.renamePasskey = async (req, res) => {
+  try {
+    const { userId, credentialId } = req.params;
+    const { name } = req.body || {};
+    if (!name || !String(name).trim()) {
+      return sendErrorResponse(res, 400, "name is required");
+    }
+
+    const passkey = await Passkey.getById(credentialId);
+    if (!passkey || passkey.userId !== userId) {
+      return sendErrorResponse(res, 404, "Passkey not found");
+    }
+
+    const trimmed = String(name).trim().slice(0, MAX_PASSKEY_NAME_LENGTH);
+    await Passkey.rename(credentialId, trimmed);
+
+    sendSuccessResponse(res, 200, "Passkey renamed", {
+      passkey: serializePasskey({ ...passkey, name: trimmed }),
+    });
+  } catch (error) {
+    sendErrorResponse(res, 500, "Failed to rename passkey", error.message);
+  }
+};
+
+/**
+ * @swagger
+ * /passkeys/{userId}/{credentialId}:
+ *   delete:
+ *     summary: Delete a passkey
+ *     tags: [Passkeys]
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: credentialId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Passkey deleted
+ *       404:
+ *         description: Passkey not found
+ */
+exports.deletePasskey = async (req, res) => {
+  try {
+    const { userId, credentialId } = req.params;
+    const passkey = await Passkey.getById(credentialId);
+    if (!passkey || passkey.userId !== userId) {
+      return sendErrorResponse(res, 404, "Passkey not found");
+    }
+
+    await Passkey.remove(credentialId);
+    sendSuccessResponse(res, 200, "Passkey deleted", { id: credentialId });
+  } catch (error) {
+    sendErrorResponse(res, 500, "Failed to delete passkey", error.message);
+  }
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -44,6 +44,16 @@ const {
   refineSummary,
 } = require("./controllers/controllers");
 
+const {
+  getRegistrationOptions,
+  verifyRegistration,
+  getAuthenticationOptions,
+  verifyAuthentication,
+  listPasskeys,
+  renamePasskey,
+  deletePasskey,
+} = require("./controllers/passkeyController");
+
 const app = express();
 app.use(express.json());
 
@@ -172,6 +182,15 @@ app.post("/content-rewriting", contentRewriting);
 app.get("/search-documents/:userId", searchDocuments);
 app.post("/process-audio", processAudioFile);
 app.post("/refine-summary", refineSummary);
+
+// Passkey (WebAuthn) routes
+app.post("/passkey/register/options", getRegistrationOptions);
+app.post("/passkey/register/verify", verifyRegistration);
+app.post("/passkey/authenticate/options", getAuthenticationOptions);
+app.post("/passkey/authenticate/verify", verifyAuthentication);
+app.get("/passkeys/:userId", listPasskeys);
+app.patch("/passkeys/:userId/:credentialId", renamePasskey);
+app.delete("/passkeys/:userId/:credentialId", deletePasskey);
 
 // Error handling for unsupported routes
 app.use((req, res) => {

--- a/backend/models/passkeyModel.js
+++ b/backend/models/passkeyModel.js
@@ -1,0 +1,158 @@
+const firebaseAdmin = require("firebase-admin");
+// Requiring the services module guarantees Firebase Admin has been initialized
+// (its initializeApp call runs on first load) and hands us the shared Firestore
+// instance so passkeys live alongside the rest of the user data.
+const { firestore } = require("../services/services");
+
+const PASSKEYS_COLLECTION = "passkeys";
+const CHALLENGES_COLLECTION = "webauthnChallenges";
+
+/**
+ * Normalize a Firestore Timestamp / Date / ISO string to epoch milliseconds.
+ * @param {*} value - Timestamp, Date, string, or nullish
+ * @returns {number} - Epoch milliseconds (0 when not parseable)
+ */
+const toMillis = (value) => {
+  if (!value) return 0;
+  if (typeof value.toMillis === "function") return value.toMillis();
+  if (value instanceof Date) return value.getTime();
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
+};
+
+/**
+ * Convert a stored timestamp to an ISO string for API responses.
+ * @param {*} value - Timestamp, Date, string, or nullish
+ * @returns {string|null} - ISO 8601 string, or null
+ */
+const toIso = (value) => {
+  const ms = toMillis(value);
+  return ms ? new Date(ms).toISOString() : null;
+};
+
+/**
+ * Passkey Model - Stores WebAuthn credentials in Firestore.
+ *
+ * Each document represents a single passkey and is keyed by the credential ID
+ * (a base64url string, which is a valid Firestore document ID). A user may own
+ * any number of passkeys; they are linked back to the account via `userId`.
+ */
+const Passkey = {
+  /**
+   * Persist a new passkey credential.
+   * @param {object} passkey - Fully-formed passkey document
+   */
+  async create(passkey) {
+    await firestore
+      .collection(PASSKEYS_COLLECTION)
+      .doc(passkey.credentialId)
+      .set(passkey);
+  },
+
+  /**
+   * Look up a single passkey by its credential ID.
+   * @param {string} credentialId - base64url credential ID
+   * @returns {Promise<object|null>} - Passkey document or null
+   */
+  async getById(credentialId) {
+    const doc = await firestore
+      .collection(PASSKEYS_COLLECTION)
+      .doc(credentialId)
+      .get();
+    return doc.exists ? doc.data() : null;
+  },
+
+  /**
+   * List every passkey belonging to a user.
+   * @param {string} userId - Firebase Auth user ID
+   * @returns {Promise<object[]>} - Array of passkey documents
+   */
+  async listByUser(userId) {
+    const snapshot = await firestore
+      .collection(PASSKEYS_COLLECTION)
+      .where("userId", "==", userId)
+      .get();
+    return snapshot.docs.map((doc) => doc.data());
+  },
+
+  /**
+   * Update the signature counter and last-used timestamp after a login.
+   * @param {string} credentialId - base64url credential ID
+   * @param {number} counter - New signature counter from the authenticator
+   */
+  async updateCounter(credentialId, counter) {
+    await firestore
+      .collection(PASSKEYS_COLLECTION)
+      .doc(credentialId)
+      .update({ counter, lastUsedAt: new Date() });
+  },
+
+  /**
+   * Rename a passkey.
+   * @param {string} credentialId - base64url credential ID
+   * @param {string} name - New display name
+   */
+  async rename(credentialId, name) {
+    await firestore
+      .collection(PASSKEYS_COLLECTION)
+      .doc(credentialId)
+      .update({ name });
+  },
+
+  /**
+   * Delete a passkey.
+   * @param {string} credentialId - base64url credential ID
+   */
+  async remove(credentialId) {
+    await firestore.collection(PASSKEYS_COLLECTION).doc(credentialId).delete();
+  },
+};
+
+/**
+ * Challenge Model - Short-lived WebAuthn challenges.
+ *
+ * Challenges are stored server-side (rather than in a cookie/session) so the
+ * flow works across the stateless, serverless backend. Each challenge is keyed
+ * by a random flow ID handed to the client, and is deleted as soon as it is
+ * consumed. Stale entries are rejected by the controller's TTL check.
+ */
+const Challenge = {
+  /**
+   * Save a challenge for an in-flight registration or authentication.
+   * @param {string} flowId - Random per-flow identifier
+   * @param {object} data - { challenge, type, userId?, rpID, origin }
+   */
+  async save(flowId, data) {
+    await firestore
+      .collection(CHALLENGES_COLLECTION)
+      .doc(flowId)
+      .set({ ...data, createdAt: new Date() });
+  },
+
+  /**
+   * Retrieve a challenge by flow ID.
+   * @param {string} flowId - Random per-flow identifier
+   * @returns {Promise<object|null>} - Challenge document or null
+   */
+  async get(flowId) {
+    const doc = await firestore
+      .collection(CHALLENGES_COLLECTION)
+      .doc(flowId)
+      .get();
+    return doc.exists ? doc.data() : null;
+  },
+
+  /**
+   * Delete a challenge once it has been consumed (best-effort).
+   * @param {string} flowId - Random per-flow identifier
+   */
+  async remove(flowId) {
+    await firestore
+      .collection(CHALLENGES_COLLECTION)
+      .doc(flowId)
+      .delete()
+      .catch(() => {});
+  },
+};
+
+module.exports = { Passkey, Challenge, toMillis, toIso };

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -704,6 +704,178 @@ paths:
           description: Summary refined successfully
         400:
           description: Invalid input
+  /passkey/register/options:
+    post:
+      summary: Begin passkey registration
+      description: Generate WebAuthn registration options (a challenge) for the signed-in user. Returns a flowId that must be echoed back on verify.
+      tags:
+        - Passkeys
+      operationId: getPasskeyRegistrationOptions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: string
+              required:
+                - userId
+      responses:
+        200:
+          description: Registration options generated
+        404:
+          description: User not found
+  /passkey/register/verify:
+    post:
+      summary: Complete passkey registration
+      description: Verify the authenticator attestation and store the new credential.
+      tags:
+        - Passkeys
+      operationId: verifyPasskeyRegistration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: string
+                flowId:
+                  type: string
+                name:
+                  type: string
+                response:
+                  type: object
+                  description: The RegistrationResponseJSON produced by the browser.
+              required:
+                - userId
+                - flowId
+                - response
+      responses:
+        201:
+          description: Passkey registered successfully
+        400:
+          description: Verification failed or session expired
+        409:
+          description: Passkey already registered
+  /passkey/authenticate/options:
+    post:
+      summary: Begin passkey authentication
+      description: Generate WebAuthn authentication options. Provide an email to scope to that account's credentials, or omit it for a discoverable (usernameless) flow.
+      tags:
+        - Passkeys
+      operationId: getPasskeyAuthenticationOptions
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+      responses:
+        200:
+          description: Authentication options generated
+  /passkey/authenticate/verify:
+    post:
+      summary: Complete passkey authentication
+      description: Verify the authenticator assertion and, on success, return a Firebase custom token and userId (the same contract as /login).
+      tags:
+        - Passkeys
+      operationId: verifyPasskeyAuthentication
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                flowId:
+                  type: string
+                response:
+                  type: object
+                  description: The AuthenticationResponseJSON produced by the browser.
+              required:
+                - flowId
+                - response
+      responses:
+        200:
+          description: Authentication successful; returns customToken and userId
+        401:
+          description: Passkey not recognized or verification failed
+  /passkeys/{userId}:
+    get:
+      summary: List a user's passkeys
+      tags:
+        - Passkeys
+      operationId: listPasskeys
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Passkeys retrieved successfully
+  /passkeys/{userId}/{credentialId}:
+    patch:
+      summary: Rename a passkey
+      tags:
+        - Passkeys
+      operationId: renamePasskey
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: credentialId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+      responses:
+        200:
+          description: Passkey renamed
+        404:
+          description: Passkey not found
+    delete:
+      summary: Delete a passkey
+      tags:
+        - Passkeys
+      operationId: deletePasskey
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: credentialId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Passkey deleted
+        404:
+          description: Passkey not found
 components:
   schemas:
     User:
@@ -731,3 +903,31 @@ components:
           type: string
         code:
           type: integer
+    Passkey:
+      type: object
+      description: A registered WebAuthn passkey (public metadata only; the public key is never returned).
+      properties:
+        id:
+          type: string
+          description: The credential ID (base64url), used as the document key.
+        name:
+          type: string
+        deviceType:
+          type: string
+          enum:
+            - singleDevice
+            - multiDevice
+        backedUp:
+          type: boolean
+          description: Whether the credential is synced/backed up across the user's devices.
+        transports:
+          type: array
+          items:
+            type: string
+        createdAt:
+          type: string
+          format: date-time
+        lastUsedAt:
+          type: string
+          format: date-time
+          nullable: true

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "docuthinker-fullstack-app-backed",
+  "name": "docuthinker-fullstack-app-backend",
   "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "docuthinker-fullstack-app-backed",
+      "name": "docuthinker-fullstack-app-backend",
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
@@ -15,6 +15,7 @@
         "@graphql-tools/schema": "^10.0.16",
         "@graphql-tools/utils": "^10.7.2",
         "@mui/material": "^5.0.0",
+        "@simplewebauthn/server": "^13.3.1",
         "axios": "^1.7.7",
         "busboy": "^1.6.0",
         "cors": "^2.8.5",
@@ -3262,6 +3263,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -4141,6 +4148,12 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.16.7",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.7.tgz",
@@ -4399,6 +4412,174 @@
       "optional": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.7.0.tgz",
+      "integrity": "sha512-iD3VskhVQnM4nE3PN9cBdPTR7JrqZy3FYk+uD2CeG6DUqKoANqaEfx0f7izPmW+Qm5JBM35ek+viLCmjy18ByQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.7.0.tgz",
+      "integrity": "sha512-hew63shtzzvBcSHbhm+cyAmKe6AIfinT9hzEqSPjDC6opTTMKmTkQ0gHuN2KsWlvqiKw1S/fS94fhag/FJkioQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.7.0.tgz",
+      "integrity": "sha512-VVsAyGqErT9D1SY4aEqozThXMVI+ssVRiv2DDeYuvpBKLIgZ3hYs3Ay3u/VSoKq6ESFi9cf6rf3IOOzfwh7oMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.7.0.tgz",
+      "integrity": "sha512-n7KEs/Q/wrB415cxy4fHOBhegp4NdJ15fkJPwcB/3/8iNBQC2L/N7SChJPKDJPZGYH0jD4Tg4/0vnHmwghnbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.7.0.tgz",
+      "integrity": "sha512-V/nrlQVmhg7lYAsM7E13UDL5erAwFv6kCIVFqNaMIHSVi7dngcT839JkRTkQBqznMG98l2XjxYk74ZztAohZzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-rsa": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.7.0.tgz",
+      "integrity": "sha512-9GTl1nE8Mx1kTZ+7QyYatDyKsm34QcWRBFkY1iPvWC3X4Dona5s/tlLiQsx5WzVdZqiMBZNYT0buyw4/vbhnjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.7.0.tgz",
+      "integrity": "sha512-Bh7m+OuIaSEllPQcSd9OSp93F4ROWH7sbITWV8MI+8dwsjE5111/87VxiWVvYFKyww3vp39geLv9ENqhwWHcew==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.7.0",
+        "@peculiar/asn1-pfx": "^2.7.0",
+        "@peculiar/asn1-pkcs8": "^2.7.0",
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "@peculiar/asn1-x509-attr": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.7.0.tgz",
+      "integrity": "sha512-/qvENQrXyTZURjMqSeofHul0JJt2sNSzSwk36pl2olkHbaioMQgrASDZAlHXl0xUlnVbHj0uGgOrBMTb5x2aJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.7.0.tgz",
+      "integrity": "sha512-W8ZfWzLmQnrcky+eh3tni4IozMdqBDiHWU0N+vve/UGjMaUs8c0L7A2oEdkBXS8rTpWDpK/aoI3DG/L/hxmxPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.7.0.tgz",
+      "integrity": "sha512-mUn9RRrkGDnG4ALfunDmzyRW5dg+sWCj/pfnCCqEHYbkGxEpvUt6iVJv8Yw1cyp6SWZ26ZE5oSmI5SqEaen15g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.7.0.tgz",
+      "integrity": "sha512-NS8e7SOgXipkzUPLF/sce7ukpMpWjhxYsH0n6Y+bHYo4TTxOb95Zv7hqwSuL212mj5YxovjdOKQOgH1As3E94w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/asn1-x509": "^2.7.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4664,6 +4845,25 @@
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
       "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA=="
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.1.tgz",
+      "integrity": "sha512-GV/oM/qeycWn8p42JZIMJBsXWQcNFg+nJFzeQTnMA4gN8mXg0+HZFWJerHg8ZN/zlveMS3iV1wzuFpOVWS/46w==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -6167,6 +6367,20 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
@@ -16565,6 +16779,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -16996,6 +17228,12 @@
         "@redis/search": "1.2.0",
         "@redis/time-series": "1.1.0"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
@@ -19229,9 +19467,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -19251,6 +19490,24 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "@graphql-tools/schema": "^10.0.16",
     "@graphql-tools/utils": "^10.7.2",
     "@mui/material": "^5.0.0",
+    "@simplewebauthn/server": "^13.3.1",
     "axios": "^1.7.7",
     "busboy": "^1.6.0",
     "cors": "^2.8.5",

--- a/backend/swagger/swagger.js
+++ b/backend/swagger/swagger.js
@@ -57,6 +57,7 @@ const swaggerOptions = {
   apis: [
     path.resolve(__dirname, "../index.js"),
     path.resolve(__dirname, "../controllers/controllers.js"),
+    path.resolve(__dirname, "../controllers/passkeyController.js"),
     path.resolve(__dirname, "../models/models.js"),
   ],
 };

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -22,6 +22,7 @@ The **DocuThinker Frontend** is built using **React** and **Material-UI** to cre
 
 - Upload documents (PDF or Word) for AI-based summarization and key insights generation.
 - Register, log in, and reset their passwords.
+- Sign in passwordlessly with **passkeys** (WebAuthn) and manage them from a dedicated Passkeys page.
 - View and interact with the document processing results in a user-friendly way.
 
 ## User Interfaces
@@ -147,16 +148,22 @@ DocuThinker-AI-App/
 │   │   │   ├── ChatModal.js          # Chat modal component
 │   │   │   ├── Spinner.js            # Loading spinner component
 │   │   │   ├── UploadModal.js        # Document upload modal component
-│   │   │   ├── Navbar.js             # Navigation bar component
+│   │   │   ├── PasskeyPromptModal.js # Post-sign-up "create a passkey" modal
+│   │   │   ├── Navbar.js             # Navigation bar (with Account dropdown)
 │   │   │   ├── Footer.js             # Footer component
 │   │   │   └── GoogleAnalytics.js    # Google Analytics integration component
 │   │   ├── pages/
 │   │   │   ├── Home.js               # Home page where documents are uploaded
 │   │   │   ├── LandingPage.js        # Welcome and information page
-│   │   │   ├── Login.js              # Login page
+│   │   │   ├── Login.js              # Login page (incl. "Sign in with a passkey")
 │   │   │   ├── Register.js           # Registration page
+│   │   │   ├── Passkeys.js           # Passkey management page (add/rename/delete)
 │   │   │   ├── ForgotPassword.js     # Forgot password page
 │   │   │   └── HowToUse.js           # Page explaining how to use the app
+│   │   ├── utils/
+│   │   │   ├── auth.js               # Event-driven client session helper
+│   │   │   ├── api.js                # Centralized API base URL
+│   │   │   └── passkeys.js           # WebAuthn (passkey) client helpers
 │   │   ├── App.js                    # Main App component
 │   │   ├── index.js                  # Entry point for the React app
 │   │   ├── App.css                   # Global CSS 1
@@ -244,6 +251,24 @@ flowchart LR
     C -.->|remove| LS
 ```
 
+## Passkeys (WebAuthn)
+
+Passwordless sign-in is implemented with [`@simplewebauthn/browser`](https://simplewebauthn.dev/), wrapped in
+`src/utils/passkeys.js`. The browser library and the backend's `@simplewebauthn/server` are a matched pair: the
+server emits the options JSON consumed here, and the response JSON produced here is verified verbatim by the
+server.
+
+| Surface | What it does |
+|---|---|
+| `pages/Login.js` | "Sign in with a passkey" button — discoverable (usernameless) or email-scoped. On success it calls the same `setAuth(token, userId)` as password login. |
+| `components/PasskeyPromptModal.js` | Shown right after sign-up to invite the user to enroll their first passkey (a styled modal, **never** a native `alert`/`prompt`). |
+| `pages/Passkeys.js` | Account-only page (guarded by `RequireAuth`) to add, rename, and delete multiple passkeys, with "Synced / This device" badges and themed dialogs. |
+| `components/Navbar.js` | When signed in, the Logout button becomes an **Account** dropdown → **Passkeys** + **Log Out** (Log Out stays destructive-red); the mobile drawer gets a Passkeys entry. |
+
+`utils/passkeys.js` exposes `isPasskeySupported()`, `registerPasskey()`, `authenticateWithPasskey()`,
+`listPasskeys()`, `renamePasskey()`, and `deletePasskey()`. The backend origin comes from `utils/api.js`
+(`REACT_APP_API_BASE_URL`, falling back to the deployed backend).
+
 ## Prerequisites
 
 Before you begin, ensure you have the following installed on your machine:
@@ -279,6 +304,7 @@ Ensure you have an `.env` file in the `frontend/` directory with the necessary e
 
 ```bash
 REACT_APP_BACKEND_URL=http://localhost:3000       # Backend URL for API requests
+REACT_APP_API_BASE_URL=http://localhost:3000      # Backend origin for passkey/API calls (optional; defaults to the deployed backend)
 REACT_APP_GOOGLE_ANALYTICS_ID=G-XXXXXX            # Google Analytics ID (optional)
 ```
 
@@ -328,6 +354,7 @@ Here are the most important scripts available in the `package.json`:
 
 - **Document Upload**: Users can upload documents (PDF, Word, plain text). PDF/DOCX are parsed **client-side** with `pdfjs-dist` and `mammoth` so the backend only ever receives plain text — keeping the request payload small and Vercel-serverless-friendly.
 - **Authentication**: Email/password, Google OAuth, and password reset. Session state is event-driven via `utils/auth.js` (see the diagram above) — no polling, no prop drilling.
+- **Passkeys (WebAuthn)**: Passwordless sign-in with fingerprint, face, or device PIN via `@simplewebauthn/browser`. Users can register multiple passkeys, are invited to create one right after sign-up (a styled modal — never a native prompt), and manage them (add/rename/delete) on the **Passkeys** page reached from the navbar **Account** dropdown. Passkey login reuses the same `setAuth(token, userId)` flow as password login.
 - **Auto-logout on token expiry**: A single `setTimeout`, clamped to the 32-bit limit, fires `clearAuth` when the JWT's `exp` is reached.
 - **Cross-tab sync**: Sign out in one tab and other open tabs update instantly via the native `storage` event.
 - **Google Analytics Integration**: User activity is tracked via Google Analytics.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/icons-material": "^6.1.2",
         "@mui/material": "^6.4.9",
         "@react-oauth/google": "^0.12.1",
+        "@simplewebauthn/browser": "^13.3.0",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -5878,6 +5879,12 @@
     },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.10.4",
+      "license": "MIT"
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@mui/icons-material": "^6.1.2",
     "@mui/material": "^6.4.9",
     "@react-oauth/google": "^0.12.1",
+    "@simplewebauthn/browser": "^13.3.0",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,6 +19,7 @@ import LandingPage from "./pages/LandingPage";
 import ForgotPassword from "./pages/ForgotPassword";
 import DocumentsPage from "./pages/DocumentsPage";
 import Profile from "./pages/Profile";
+import Passkeys from "./pages/Passkeys";
 import PrivacyPolicy from "./pages/PrivacyPolicy";
 import NotFoundPage from "./pages/NotFoundPage";
 import TermsOfService from "./pages/TermsOfService";
@@ -50,6 +51,11 @@ function useTrackPageView() {
 // Redirect logged-in users away from guest-only pages.
 function RequireGuest({ children }) {
   return isAuthenticated() ? <Navigate to="/home" replace /> : children;
+}
+
+// Redirect signed-out users away from account-only pages.
+function RequireAuth({ children }) {
+  return isAuthenticated() ? children : <Navigate to="/login" replace />;
 }
 
 // Launches the app
@@ -104,6 +110,14 @@ function AppLayout({ theme, onThemeToggle }) {
             }
           />
           <Route path="/profile" element={<Profile theme={theme} />} />
+          <Route
+            path="/passkeys"
+            element={
+              <RequireAuth>
+                <Passkeys theme={theme} />
+              </RequireAuth>
+            }
+          />
           <Route
             path="/privacy-policy"
             element={<PrivacyPolicy theme={theme} />}

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -11,6 +11,9 @@ import {
   ListItem,
   ListItemText,
   ListItemIcon,
+  Menu,
+  MenuItem,
+  Divider,
   useMediaQuery,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
@@ -25,6 +28,9 @@ import PersonIcon from "@mui/icons-material/Person";
 import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 import LoginIcon from "@mui/icons-material/Login";
 import AppRegistrationIcon from "@mui/icons-material/AppRegistration";
+import AccountCircleIcon from "@mui/icons-material/AccountCircle";
+import VpnKeyIcon from "@mui/icons-material/VpnKey";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import { isAuthenticated, clearAuth, onAuthChange } from "../utils/auth";
 
 const activeStyle = {
@@ -36,8 +42,10 @@ const activeStyle = {
 const Navbar = ({ theme, onThemeToggle }) => {
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [accountAnchor, setAccountAnchor] = useState(null);
   const navigate = useNavigate();
   const isLargeScreen = useMediaQuery("(min-width:1111px)");
+  const accountMenuOpen = Boolean(accountAnchor);
 
   useEffect(() => {
     const sync = () => setIsLoggedIn(isAuthenticated());
@@ -55,7 +63,16 @@ const Navbar = ({ theme, onThemeToggle }) => {
     setDrawerOpen(open);
   };
 
+  const handleAccountOpen = (event) => setAccountAnchor(event.currentTarget);
+  const handleAccountClose = () => setAccountAnchor(null);
+
+  const handlePasskeys = () => {
+    handleAccountClose();
+    navigate("/passkeys");
+  };
+
   const handleLogout = () => {
+    handleAccountClose();
     clearAuth();
     navigate("/login");
   };
@@ -144,21 +161,80 @@ const Navbar = ({ theme, onThemeToggle }) => {
       </Button>
 
       {isLoggedIn ? (
-        <Button
-          onClick={handleLogout}
-          sx={{
-            color: "red",
-            "&:hover": { color: "white", transform: "scale(1.04)" },
-            marginRight: 2,
-            font: "inherit",
-            textTransform: "none",
-            display: "flex",
-            alignItems: "center",
-            transition: "transform 0.2s ease",
-          }}
-        >
-          <ExitToAppIcon sx={{ marginRight: 1 }} /> Logout
-        </Button>
+        <>
+          <Button
+            onClick={handleAccountOpen}
+            aria-haspopup="true"
+            aria-expanded={accountMenuOpen ? "true" : undefined}
+            endIcon={
+              <KeyboardArrowDownIcon
+                sx={{
+                  transition: "transform 0.2s ease",
+                  transform: accountMenuOpen ? "rotate(180deg)" : "none",
+                }}
+              />
+            }
+            sx={{
+              color: theme === "dark" ? "white" : "black",
+              marginRight: 2,
+              font: "inherit",
+              textTransform: "none",
+              display: "flex",
+              alignItems: "center",
+              transition: "transform 0.2s ease",
+              "&:hover": {
+                bgcolor: theme === "dark" ? "#444" : "#f5f5f5",
+                transform: { xs: "none", md: "scale(1.04)" },
+              },
+            }}
+          >
+            <AccountCircleIcon sx={{ marginRight: 1 }} /> Account
+          </Button>
+          <Menu
+            anchorEl={accountAnchor}
+            open={accountMenuOpen}
+            onClose={handleAccountClose}
+            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+            transformOrigin={{ vertical: "top", horizontal: "right" }}
+            PaperProps={{
+              sx: {
+                mt: 1,
+                minWidth: 180,
+                borderRadius: "12px",
+                bgcolor: theme === "dark" ? "#2a2a2a" : "white",
+                color: theme === "dark" ? "white" : "black",
+                boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+                fontFamily: "Poppins, sans-serif",
+              },
+            }}
+          >
+            <MenuItem
+              onClick={handlePasskeys}
+              sx={{
+                font: "inherit",
+                py: 1.2,
+                "&:hover": { bgcolor: theme === "dark" ? "#3a3a3a" : "#f5f5f5" },
+              }}
+            >
+              <VpnKeyIcon sx={{ marginRight: 1.5, color: "#f57c00" }} /> Passkeys
+            </MenuItem>
+            <Divider sx={{ borderColor: theme === "dark" ? "#3a3a3a" : "#eee" }} />
+            <MenuItem
+              onClick={handleLogout}
+              sx={{
+                font: "inherit",
+                py: 1.2,
+                color: "red",
+                "&:hover": {
+                  bgcolor: theme === "dark" ? "#3a3a3a" : "#fdeded",
+                  color: "red",
+                },
+              }}
+            >
+              <ExitToAppIcon sx={{ marginRight: 1.5, color: "red" }} /> Log Out
+            </MenuItem>
+          </Menu>
+        </>
       ) : (
         <Button
           component={NavLink}
@@ -369,24 +445,49 @@ const Navbar = ({ theme, onThemeToggle }) => {
               <ListItemText disableTypography primary="Profile" />
             </ListItem>
             {isLoggedIn ? (
-              <ListItem
-                button
-                onClick={handleLogout}
-                sx={{
-                  color: "red",
-                  "&:hover": {
+              <>
+                <ListItem
+                  button
+                  component={NavLink}
+                  to="/passkeys"
+                  sx={{
+                    color: theme === "dark" ? "white" : "black",
+                    "&:hover": {
+                      color: theme === "dark" ? "white" : "black",
+                      bgcolor: theme === "dark" ? "#444" : "#f5f5f5",
+                    },
+                    borderRadius: "8px",
+                  }}
+                >
+                  <ListItemIcon
+                    sx={{
+                      minWidth: "40px",
+                      color: theme === "dark" ? "white" : "black",
+                    }}
+                  >
+                    <VpnKeyIcon />
+                  </ListItemIcon>
+                  <ListItemText disableTypography primary="Passkeys" />
+                </ListItem>
+                <ListItem
+                  button
+                  onClick={handleLogout}
+                  sx={{
                     color: "red",
-                    bgcolor: theme === "dark" ? "#444" : "#f5f5f5",
-                  },
-                  borderRadius: "8px",
-                  cursor: "pointer",
-                }}
-              >
-                <ListItemIcon sx={{ minWidth: "40px", color: "red" }}>
-                  <ExitToAppIcon />
-                </ListItemIcon>
-                <ListItemText disableTypography primary="Logout" />
-              </ListItem>
+                    "&:hover": {
+                      color: "red",
+                      bgcolor: theme === "dark" ? "#444" : "#f5f5f5",
+                    },
+                    borderRadius: "8px",
+                    cursor: "pointer",
+                  }}
+                >
+                  <ListItemIcon sx={{ minWidth: "40px", color: "red" }}>
+                    <ExitToAppIcon />
+                  </ListItemIcon>
+                  <ListItemText disableTypography primary="Log Out" />
+                </ListItem>
+              </>
             ) : (
               <ListItem
                 button

--- a/frontend/src/components/PasskeyPromptModal.js
+++ b/frontend/src/components/PasskeyPromptModal.js
@@ -1,0 +1,246 @@
+import React, { useState } from "react";
+import {
+  Modal,
+  Box,
+  Typography,
+  Button,
+  CircularProgress,
+  Alert,
+  Fade,
+} from "@mui/material";
+import FingerprintIcon from "@mui/icons-material/Fingerprint";
+import BoltIcon from "@mui/icons-material/Bolt";
+import LockIcon from "@mui/icons-material/Lock";
+import DevicesIcon from "@mui/icons-material/Devices";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import { registerPasskey } from "../utils/passkeys";
+
+const ORANGE = "#f57c00";
+
+const Benefit = ({ icon, title, subtitle, theme }) => (
+  <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.5, mb: 1.5 }}>
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 36,
+        height: 36,
+        borderRadius: "10px",
+        flexShrink: 0,
+        bgcolor: theme === "dark" ? "rgba(245,124,0,0.16)" : "rgba(245,124,0,0.12)",
+        color: ORANGE,
+      }}
+    >
+      {icon}
+    </Box>
+    <Box sx={{ textAlign: "left" }}>
+      <Typography
+        sx={{
+          font: "inherit",
+          fontWeight: 600,
+          fontSize: "15px",
+          color: theme === "dark" ? "white" : "#222",
+        }}
+      >
+        {title}
+      </Typography>
+      <Typography
+        sx={{
+          font: "inherit",
+          fontSize: "13px",
+          color: theme === "dark" ? "#bbb" : "#666",
+        }}
+      >
+        {subtitle}
+      </Typography>
+    </Box>
+  </Box>
+);
+
+/**
+ * Shown right after sign-up to invite the user to create their first passkey.
+ * Self-contained: it runs the WebAuthn registration using the new account's
+ * userId and reports success/failure inline.
+ */
+const PasskeyPromptModal = ({ open, onClose, userId, theme }) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [done, setDone] = useState(false);
+
+  const handleCreate = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      await registerPasskey(userId);
+      setDone(true);
+      setTimeout(() => onClose(true), 1600);
+    } catch (err) {
+      setError(err.message || "Could not create a passkey.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Modal open={open} onClose={() => (loading ? null : onClose(false))} closeAfterTransition>
+      <Fade in={open}>
+        <Box
+          sx={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            width: { xs: "90%", sm: "440px" },
+            maxHeight: "90vh",
+            overflowY: "auto",
+            bgcolor: theme === "dark" ? "#262626" : "white",
+            color: theme === "dark" ? "white" : "black",
+            borderRadius: "16px",
+            boxShadow: "0 12px 40px rgba(0,0,0,0.3)",
+            p: { xs: 3, sm: 4 },
+            textAlign: "center",
+            fontFamily: "Poppins, sans-serif",
+            outline: "none",
+          }}
+        >
+          {done ? (
+            <Box sx={{ py: 2 }}>
+              <CheckCircleIcon sx={{ fontSize: 64, color: "#2e7d32", mb: 1 }} />
+              <Typography
+                sx={{ font: "inherit", fontWeight: 600, fontSize: "20px", mb: 1 }}
+              >
+                Passkey created!
+              </Typography>
+              <Typography
+                sx={{
+                  font: "inherit",
+                  fontSize: "14px",
+                  color: theme === "dark" ? "#bbb" : "#666",
+                }}
+              >
+                You can now sign in without a password next time.
+              </Typography>
+            </Box>
+          ) : (
+            <>
+              <Box
+                sx={{
+                  width: 72,
+                  height: 72,
+                  borderRadius: "50%",
+                  mx: "auto",
+                  mb: 2,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  background:
+                    "linear-gradient(135deg, #f57c00 0%, #ff9d3f 100%)",
+                  boxShadow: "0 6px 18px rgba(245,124,0,0.4)",
+                }}
+              >
+                <FingerprintIcon sx={{ fontSize: 42, color: "white" }} />
+              </Box>
+
+              <Typography
+                sx={{
+                  font: "inherit",
+                  fontWeight: 700,
+                  fontSize: "22px",
+                  mb: 1,
+                  color: ORANGE,
+                }}
+              >
+                Set up a passkey
+              </Typography>
+              <Typography
+                sx={{
+                  font: "inherit",
+                  fontSize: "14px",
+                  mb: 3,
+                  color: theme === "dark" ? "#bbb" : "#666",
+                }}
+              >
+                Sign in to DocuThinker instantly with your fingerprint, face, or
+                screen lock — no password to remember.
+              </Typography>
+
+              <Box sx={{ mb: 1 }}>
+                <Benefit
+                  theme={theme}
+                  icon={<BoltIcon sx={{ fontSize: 20 }} />}
+                  title="Faster sign-in"
+                  subtitle="One tap with biometrics — no typing."
+                />
+                <Benefit
+                  theme={theme}
+                  icon={<LockIcon sx={{ fontSize: 20 }} />}
+                  title="More secure"
+                  subtitle="Phishing-resistant and never reused."
+                />
+                <Benefit
+                  theme={theme}
+                  icon={<DevicesIcon sx={{ fontSize: 20 }} />}
+                  title="Works everywhere"
+                  subtitle="Synced across your devices by your platform."
+                />
+              </Box>
+
+              {error && (
+                <Alert
+                  severity="error"
+                  sx={{ font: "inherit", fontSize: "13px", textAlign: "left", mb: 2 }}
+                >
+                  {error}
+                </Alert>
+              )}
+
+              <Button
+                fullWidth
+                variant="contained"
+                onClick={handleCreate}
+                disabled={loading}
+                startIcon={
+                  !loading ? <FingerprintIcon /> : null
+                }
+                sx={{
+                  bgcolor: ORANGE,
+                  color: "white",
+                  font: "inherit",
+                  fontWeight: 600,
+                  textTransform: "none",
+                  py: 1.2,
+                  borderRadius: "10px",
+                  "&:hover": { bgcolor: "#e65100" },
+                }}
+              >
+                {loading ? (
+                  <CircularProgress size={22} sx={{ color: "white" }} />
+                ) : (
+                  "Create a passkey"
+                )}
+              </Button>
+
+              <Button
+                fullWidth
+                onClick={() => onClose(false)}
+                disabled={loading}
+                sx={{
+                  mt: 1.5,
+                  font: "inherit",
+                  textTransform: "none",
+                  color: theme === "dark" ? "#bbb" : "#777",
+                  "&:hover": { bgcolor: "transparent", color: ORANGE },
+                }}
+              >
+                Maybe later
+              </Button>
+            </>
+          )}
+        </Box>
+      </Fade>
+    </Modal>
+  );
+};
+
+export default PasskeyPromptModal;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -9,19 +9,24 @@ import {
   Link,
   IconButton,
   InputAdornment,
+  Divider,
 } from "@mui/material";
 import { Visibility, VisibilityOff } from "@mui/icons-material";
+import FingerprintIcon from "@mui/icons-material/Fingerprint";
 import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import { setAuth } from "../utils/auth";
+import { authenticateWithPasskey, isPasskeySupported } from "../utils/passkeys";
 
 const Login = ({ theme }) => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [passkeyLoading, setPasskeyLoading] = useState(false);
   const [error, setError] = useState("");
   const navigate = useNavigate();
+  const passkeySupported = isPasskeySupported();
 
   const handleLogin = async (e) => {
     e.preventDefault();
@@ -50,6 +55,22 @@ const Login = ({ theme }) => {
       } else {
         setError("Login failed. Please try again.");
       }
+    }
+  };
+
+  const handlePasskeyLogin = async () => {
+    setPasskeyLoading(true);
+    setError("");
+    try {
+      const { customToken, userId } = await authenticateWithPasskey(
+        email.trim() || undefined,
+      );
+      setAuth(customToken, userId);
+      navigate("/home");
+    } catch (err) {
+      setError(err.message || "Passkey sign-in failed. Please try again.");
+    } finally {
+      setPasskeyLoading(false);
     }
   };
 
@@ -203,6 +224,53 @@ const Login = ({ theme }) => {
             )}
           </Button>
         </form>
+
+        {/* Passkey sign-in */}
+        {passkeySupported && (
+          <>
+            <Divider
+              sx={{
+                my: "1.5rem",
+                font: "inherit",
+                fontSize: "13px",
+                color: theme === "dark" ? "#aaa" : "#999",
+                "&::before, &::after": {
+                  borderColor: theme === "dark" ? "#555" : "#ddd",
+                },
+              }}
+            >
+              or
+            </Divider>
+
+            <Button
+              type="button"
+              fullWidth
+              variant="outlined"
+              onClick={handlePasskeyLogin}
+              disabled={passkeyLoading || loading}
+              startIcon={!passkeyLoading ? <FingerprintIcon /> : null}
+              sx={{
+                borderColor: "#f57c00",
+                color: "#f57c00",
+                font: "inherit",
+                fontWeight: 600,
+                textTransform: "none",
+                padding: "0.7rem",
+                borderRadius: "8px",
+                "&:hover": {
+                  borderColor: "#e65100",
+                  bgcolor: "rgba(245,124,0,0.08)",
+                },
+              }}
+            >
+              {passkeyLoading ? (
+                <CircularProgress size={22} sx={{ color: "#f57c00" }} />
+              ) : (
+                "Sign in with a passkey"
+              )}
+            </Button>
+          </>
+        )}
 
         {/* Forgot Password Link */}
         <Box

--- a/frontend/src/pages/Passkeys.js
+++ b/frontend/src/pages/Passkeys.js
@@ -1,0 +1,628 @@
+import React, { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Typography,
+  Button,
+  IconButton,
+  Chip,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  TextField,
+  Alert,
+  Snackbar,
+  Tooltip,
+  Divider,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import FingerprintIcon from "@mui/icons-material/Fingerprint";
+import VpnKeyIcon from "@mui/icons-material/VpnKey";
+import EditIcon from "@mui/icons-material/Edit";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import CloudDoneIcon from "@mui/icons-material/CloudDone";
+import SmartphoneIcon from "@mui/icons-material/Smartphone";
+import {
+  listPasskeys,
+  registerPasskey,
+  renamePasskey,
+  deletePasskey,
+  isPasskeySupported,
+} from "../utils/passkeys";
+
+const ORANGE = "#f57c00";
+
+const formatDate = (iso) => {
+  if (!iso) return null;
+  try {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch (e) {
+    return null;
+  }
+};
+
+const Passkeys = ({ theme }) => {
+  const navigate = useNavigate();
+  const userId = localStorage.getItem("userId");
+  const dark = theme === "dark";
+
+  const [passkeys, setPasskeys] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [snack, setSnack] = useState({ open: false, message: "", severity: "success" });
+
+  // Add dialog
+  const [addOpen, setAddOpen] = useState(false);
+  const [addName, setAddName] = useState("");
+  const [adding, setAdding] = useState(false);
+
+  // Rename dialog
+  const [renameTarget, setRenameTarget] = useState(null);
+  const [renameValue, setRenameValue] = useState("");
+  const [renaming, setRenaming] = useState(false);
+
+  // Delete dialog
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const supported = isPasskeySupported();
+
+  const notify = (message, severity = "success") =>
+    setSnack({ open: true, message, severity });
+
+  const load = useCallback(async () => {
+    if (!userId) return;
+    setLoading(true);
+    setError("");
+    try {
+      const data = await listPasskeys(userId);
+      setPasskeys(data);
+    } catch (err) {
+      setError(
+        (err.response && err.response.data && err.response.data.error) ||
+          "Could not load your passkeys. Please try again.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [userId]);
+
+  useEffect(() => {
+    if (!userId) {
+      navigate("/login");
+      return;
+    }
+    load();
+  }, [userId, navigate, load]);
+
+  const handleAdd = async () => {
+    setAdding(true);
+    try {
+      await registerPasskey(userId, addName.trim() || undefined);
+      setAddOpen(false);
+      setAddName("");
+      notify("Passkey added successfully.");
+      await load();
+    } catch (err) {
+      notify(err.message || "Could not create a passkey.", "error");
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleRename = async () => {
+    if (!renameValue.trim()) return;
+    setRenaming(true);
+    try {
+      await renamePasskey(userId, renameTarget.id, renameValue.trim());
+      setRenameTarget(null);
+      notify("Passkey renamed.");
+      await load();
+    } catch (err) {
+      notify(
+        (err.response && err.response.data && err.response.data.error) ||
+          "Could not rename the passkey.",
+        "error",
+      );
+    } finally {
+      setRenaming(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      await deletePasskey(userId, deleteTarget.id);
+      setDeleteTarget(null);
+      notify("Passkey removed.");
+      await load();
+    } catch (err) {
+      notify(
+        (err.response && err.response.data && err.response.data.error) ||
+          "Could not remove the passkey.",
+        "error",
+      );
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const dialogPaperSx = {
+    bgcolor: dark ? "#2a2a2a" : "white",
+    color: dark ? "white" : "black",
+    borderRadius: "14px",
+    fontFamily: "Poppins, sans-serif",
+    width: { xs: "92%", sm: "420px" },
+  };
+
+  const textFieldSx = {
+    mt: 1,
+    backgroundColor: dark ? "#3a3a3a" : "#fff",
+    borderRadius: "8px",
+    input: { color: dark ? "white" : "black", fontFamily: "Poppins, sans-serif" },
+  };
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        backgroundColor: dark ? "#1e1e1e" : "#f5f5f5",
+        transition: "background-color 0.3s ease",
+        py: { xs: 3, md: 5 },
+        px: 2,
+        fontFamily: "Poppins, sans-serif",
+      }}
+    >
+      <Box sx={{ maxWidth: "760px", mx: "auto" }}>
+        {/* Header */}
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: { xs: "column", sm: "row" },
+            alignItems: { xs: "flex-start", sm: "center" },
+            justifyContent: "space-between",
+            gap: 2,
+            mb: 3,
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+            <FingerprintIcon sx={{ fontSize: 38, color: ORANGE }} />
+            <Box>
+              <Typography
+                sx={{
+                  font: "inherit",
+                  fontWeight: 700,
+                  fontSize: { xs: "26px", md: "30px" },
+                  color: ORANGE,
+                  lineHeight: 1.1,
+                }}
+              >
+                Passkeys
+              </Typography>
+              <Typography
+                sx={{
+                  font: "inherit",
+                  fontSize: "14px",
+                  color: dark ? "#bbb" : "#666",
+                }}
+              >
+                Password-free sign-in with your fingerprint, face, or device PIN.
+              </Typography>
+            </Box>
+          </Box>
+
+          <Button
+            variant="contained"
+            startIcon={<AddIcon />}
+            disabled={!supported}
+            onClick={() => {
+              setAddName("");
+              setAddOpen(true);
+            }}
+            sx={{
+              bgcolor: ORANGE,
+              color: "white",
+              font: "inherit",
+              fontWeight: 600,
+              textTransform: "none",
+              borderRadius: "10px",
+              px: 2.5,
+              py: 1,
+              whiteSpace: "nowrap",
+              "&:hover": { bgcolor: "#e65100" },
+            }}
+          >
+            Add a passkey
+          </Button>
+        </Box>
+
+        {!supported && (
+          <Alert severity="warning" sx={{ font: "inherit", mb: 3, borderRadius: "10px" }}>
+            This browser or device doesn't support passkeys. You can still manage
+            existing passkeys here, but you'll need a compatible device to add a
+            new one.
+          </Alert>
+        )}
+
+        {error && (
+          <Alert
+            severity="error"
+            sx={{ font: "inherit", mb: 3, borderRadius: "10px" }}
+            action={
+              <Button color="inherit" size="small" onClick={load} sx={{ font: "inherit" }}>
+                Retry
+              </Button>
+            }
+          >
+            {error}
+          </Alert>
+        )}
+
+        {/* Body */}
+        {loading ? (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+            <CircularProgress sx={{ color: ORANGE }} />
+          </Box>
+        ) : passkeys.length === 0 ? (
+          <Box
+            sx={{
+              textAlign: "center",
+              py: 7,
+              px: 3,
+              borderRadius: "16px",
+              border: `2px dashed ${dark ? "#444" : "#ddd"}`,
+              bgcolor: dark ? "#262626" : "white",
+            }}
+          >
+            <VpnKeyIcon sx={{ fontSize: 56, color: dark ? "#555" : "#ccc", mb: 1 }} />
+            <Typography
+              sx={{ font: "inherit", fontWeight: 600, fontSize: "18px", mb: 0.5 }}
+            >
+              No passkeys yet
+            </Typography>
+            <Typography
+              sx={{
+                font: "inherit",
+                fontSize: "14px",
+                color: dark ? "#bbb" : "#666",
+                mb: 3,
+                maxWidth: "420px",
+                mx: "auto",
+              }}
+            >
+              Add a passkey to sign in without typing your password. Your device
+              keeps the key safe and never shares it.
+            </Typography>
+            <Button
+              variant="contained"
+              startIcon={<FingerprintIcon />}
+              disabled={!supported}
+              onClick={() => {
+                setAddName("");
+                setAddOpen(true);
+              }}
+              sx={{
+                bgcolor: ORANGE,
+                color: "white",
+                font: "inherit",
+                fontWeight: 600,
+                textTransform: "none",
+                borderRadius: "10px",
+                px: 3,
+                py: 1,
+                "&:hover": { bgcolor: "#e65100" },
+              }}
+            >
+              Add your first passkey
+            </Button>
+          </Box>
+        ) : (
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            {passkeys.map((pk) => {
+              const created = formatDate(pk.createdAt);
+              const lastUsed = formatDate(pk.lastUsedAt);
+              return (
+                <Box
+                  key={pk.id}
+                  sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 2,
+                    p: 2,
+                    borderRadius: "14px",
+                    bgcolor: dark ? "#262626" : "white",
+                    boxShadow: "0 2px 10px rgba(0,0,0,0.06)",
+                    transition: "transform 0.15s ease, box-shadow 0.15s ease",
+                    "&:hover": {
+                      transform: "translateY(-2px)",
+                      boxShadow: "0 6px 18px rgba(0,0,0,0.12)",
+                    },
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: 48,
+                      height: 48,
+                      borderRadius: "12px",
+                      flexShrink: 0,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      bgcolor: dark ? "rgba(245,124,0,0.16)" : "rgba(245,124,0,0.12)",
+                      color: ORANGE,
+                    }}
+                  >
+                    <VpnKeyIcon />
+                  </Box>
+
+                  <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      <Typography
+                        sx={{
+                          font: "inherit",
+                          fontWeight: 600,
+                          fontSize: "16px",
+                          color: dark ? "white" : "#222",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                          maxWidth: { xs: "150px", sm: "320px" },
+                        }}
+                      >
+                        {pk.name}
+                      </Typography>
+                      <Chip
+                        size="small"
+                        icon={
+                          pk.backedUp ? (
+                            <CloudDoneIcon sx={{ fontSize: 15 }} />
+                          ) : (
+                            <SmartphoneIcon sx={{ fontSize: 15 }} />
+                          )
+                        }
+                        label={pk.backedUp ? "Synced" : "This device"}
+                        sx={{
+                          font: "inherit",
+                          fontSize: "11px",
+                          height: 22,
+                          color: pk.backedUp ? "#2e7d32" : dark ? "#bbb" : "#666",
+                          bgcolor: pk.backedUp
+                            ? "rgba(46,125,50,0.12)"
+                            : dark
+                              ? "#333"
+                              : "#f0f0f0",
+                          "& .MuiChip-icon": {
+                            color: pk.backedUp ? "#2e7d32" : dark ? "#bbb" : "#666",
+                          },
+                        }}
+                      />
+                    </Box>
+                    <Typography
+                      sx={{
+                        font: "inherit",
+                        fontSize: "12.5px",
+                        color: dark ? "#999" : "#888",
+                        mt: 0.3,
+                      }}
+                    >
+                      {created ? `Added ${created}` : "Recently added"}
+                      {"  ·  "}
+                      {lastUsed ? `Last used ${lastUsed}` : "Never used"}
+                    </Typography>
+                  </Box>
+
+                  <Box sx={{ display: "flex", gap: 0.5, flexShrink: 0 }}>
+                    <Tooltip title="Rename">
+                      <IconButton
+                        onClick={() => {
+                          setRenameTarget(pk);
+                          setRenameValue(pk.name);
+                        }}
+                        sx={{ color: dark ? "#bbb" : "#666", "&:hover": { color: ORANGE } }}
+                      >
+                        <EditIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title="Remove">
+                      <IconButton
+                        onClick={() => setDeleteTarget(pk)}
+                        sx={{ color: "#d32f2f", "&:hover": { color: "#b71c1c" } }}
+                      >
+                        <DeleteOutlineIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+      </Box>
+
+      {/* Add passkey dialog */}
+      <Dialog
+        open={addOpen}
+        onClose={() => (adding ? null : setAddOpen(false))}
+        PaperProps={{ sx: dialogPaperSx }}
+      >
+        <DialogTitle sx={{ font: "inherit", fontWeight: 700, color: ORANGE }}>
+          Add a passkey
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText
+            sx={{ font: "inherit", fontSize: "14px", color: dark ? "#bbb" : "#666" }}
+          >
+            Give this passkey a name so you can recognize it later. Your browser
+            will then ask you to confirm with your device.
+          </DialogContentText>
+          <TextField
+            autoFocus
+            fullWidth
+            placeholder="e.g., MacBook Touch ID"
+            label="Passkey name (optional)"
+            value={addName}
+            onChange={(e) => setAddName(e.target.value)}
+            inputProps={{ maxLength: 60 }}
+            sx={textFieldSx}
+            InputLabelProps={{ style: { color: dark ? "#bbb" : "#666" } }}
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button
+            onClick={() => setAddOpen(false)}
+            disabled={adding}
+            sx={{ font: "inherit", textTransform: "none", color: dark ? "#bbb" : "#666" }}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleAdd}
+            disabled={adding}
+            variant="contained"
+            startIcon={!adding ? <FingerprintIcon /> : null}
+            sx={{
+              bgcolor: ORANGE,
+              color: "white",
+              font: "inherit",
+              fontWeight: 600,
+              textTransform: "none",
+              borderRadius: "8px",
+              "&:hover": { bgcolor: "#e65100" },
+            }}
+          >
+            {adding ? <CircularProgress size={20} sx={{ color: "white" }} /> : "Continue"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Rename dialog */}
+      <Dialog
+        open={!!renameTarget}
+        onClose={() => (renaming ? null : setRenameTarget(null))}
+        PaperProps={{ sx: dialogPaperSx }}
+      >
+        <DialogTitle sx={{ font: "inherit", fontWeight: 700, color: ORANGE }}>
+          Rename passkey
+        </DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            fullWidth
+            label="Passkey name"
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            inputProps={{ maxLength: 60 }}
+            sx={textFieldSx}
+            InputLabelProps={{ style: { color: dark ? "#bbb" : "#666" } }}
+          />
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button
+            onClick={() => setRenameTarget(null)}
+            disabled={renaming}
+            sx={{ font: "inherit", textTransform: "none", color: dark ? "#bbb" : "#666" }}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleRename}
+            disabled={renaming || !renameValue.trim()}
+            variant="contained"
+            sx={{
+              bgcolor: ORANGE,
+              color: "white",
+              font: "inherit",
+              fontWeight: 600,
+              textTransform: "none",
+              borderRadius: "8px",
+              "&:hover": { bgcolor: "#e65100" },
+            }}
+          >
+            {renaming ? <CircularProgress size={20} sx={{ color: "white" }} /> : "Save"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete confirm dialog */}
+      <Dialog
+        open={!!deleteTarget}
+        onClose={() => (deleting ? null : setDeleteTarget(null))}
+        PaperProps={{ sx: dialogPaperSx }}
+      >
+        <DialogTitle sx={{ font: "inherit", fontWeight: 700 }}>
+          Remove passkey?
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText
+            sx={{ font: "inherit", fontSize: "14px", color: dark ? "#bbb" : "#666" }}
+          >
+            {deleteTarget ? (
+              <>
+                You won't be able to sign in with{" "}
+                <strong>{deleteTarget.name}</strong> anymore. This can't be
+                undone, but you can always add a new passkey later.
+              </>
+            ) : null}
+          </DialogContentText>
+        </DialogContent>
+        <Divider sx={{ borderColor: dark ? "#3a3a3a" : "#eee" }} />
+        <DialogActions sx={{ px: 3, py: 2 }}>
+          <Button
+            onClick={() => setDeleteTarget(null)}
+            disabled={deleting}
+            sx={{ font: "inherit", textTransform: "none", color: dark ? "#bbb" : "#666" }}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleDelete}
+            disabled={deleting}
+            variant="contained"
+            sx={{
+              bgcolor: "#d32f2f",
+              color: "white",
+              font: "inherit",
+              fontWeight: 600,
+              textTransform: "none",
+              borderRadius: "8px",
+              "&:hover": { bgcolor: "#b71c1c" },
+            }}
+          >
+            {deleting ? <CircularProgress size={20} sx={{ color: "white" }} /> : "Remove"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={snack.open}
+        autoHideDuration={5000}
+        onClose={() => setSnack((s) => ({ ...s, open: false }))}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Alert
+          severity={snack.severity}
+          onClose={() => setSnack((s) => ({ ...s, open: false }))}
+          sx={{ font: "inherit", width: "100%" }}
+        >
+          {snack.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};
+
+export default Passkeys;

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -12,6 +12,8 @@ import {
 import { Visibility, VisibilityOff } from "@mui/icons-material";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import PasskeyPromptModal from "../components/PasskeyPromptModal";
+import { isPasskeySupported } from "../utils/passkeys";
 
 const Register = ({ theme }) => {
   const [email, setEmail] = useState("");
@@ -22,6 +24,8 @@ const Register = ({ theme }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState("");
+  const [passkeyModalOpen, setPasskeyModalOpen] = useState(false);
+  const [newUserId, setNewUserId] = useState(null);
   const navigate = useNavigate();
 
   const handleRegister = async (e) => {
@@ -43,15 +47,20 @@ const Register = ({ theme }) => {
       );
       setLoading(false);
       setSuccess("User registered successfully! You can now login.");
-      setEmail("");
       setPassword("");
       setConfirmPassword("");
 
-      setTimeout(() => {
-        navigate("/login");
-      }, 1500);
-
-      console.log(response.data);
+      const registeredUserId = response.data && response.data.userId;
+      if (registeredUserId && isPasskeySupported()) {
+        // Invite the brand-new user to set up a passkey before sending them
+        // to the login page.
+        setNewUserId(registeredUserId);
+        setPasskeyModalOpen(true);
+      } else {
+        setTimeout(() => {
+          navigate("/login");
+        }, 1500);
+      }
     } catch (err) {
       setLoading(false);
       setError(err.response?.data.details || err.message);
@@ -67,7 +76,14 @@ const Register = ({ theme }) => {
     setShowConfirmPassword((prev) => !prev);
   };
 
+  const handlePasskeyModalClose = () => {
+    setPasskeyModalOpen(false);
+    setEmail("");
+    navigate("/login");
+  };
+
   return (
+    <>
     <Box
       sx={{
         maxWidth: "400px",
@@ -267,6 +283,14 @@ const Register = ({ theme }) => {
         </Typography>
       </form>
     </Box>
+
+      <PasskeyPromptModal
+        open={passkeyModalOpen}
+        userId={newUserId}
+        theme={theme}
+        onClose={handlePasskeyModalClose}
+      />
+    </>
   );
 };
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,0 +1,8 @@
+// Single source of truth for the backend API origin.
+//
+// Defaults to the deployed backend the rest of the app already targets, but can
+// be overridden at build time (e.g. for local development) via
+// REACT_APP_API_BASE_URL.
+export const API_BASE_URL =
+  process.env.REACT_APP_API_BASE_URL ||
+  "https://docuthinker-app-backend-api.vercel.app";

--- a/frontend/src/utils/passkeys.js
+++ b/frontend/src/utils/passkeys.js
@@ -1,0 +1,101 @@
+// Client-side passkey (WebAuthn) helpers.
+//
+// Thin wrapper around @simplewebauthn/browser plus the backend's passkey
+// endpoints. The browser library and the backend's @simplewebauthn/server are a
+// matched pair: the server emits the options JSON consumed here, and the
+// response JSON produced here is verified verbatim by the server.
+
+import axios from "axios";
+import {
+  startRegistration,
+  startAuthentication,
+  browserSupportsWebAuthn,
+  platformAuthenticatorIsAvailable,
+} from "@simplewebauthn/browser";
+import { API_BASE_URL } from "./api";
+
+// Whether this browser can use WebAuthn at all.
+export const isPasskeySupported = () => browserSupportsWebAuthn();
+
+// Whether a built-in authenticator (Touch ID, Windows Hello, etc.) is present.
+export const isPlatformAuthenticatorAvailable = async () => {
+  try {
+    return await platformAuthenticatorIsAvailable();
+  } catch (e) {
+    return false;
+  }
+};
+
+// Turn a WebAuthn/axios failure into a message that's safe to show a user.
+const friendlyError = (err, fallback) => {
+  if (err && err.name === "NotAllowedError") {
+    return "The passkey request was cancelled or timed out. Please try again.";
+  }
+  if (err && err.name === "InvalidStateError") {
+    return "A passkey for this account already exists on this device.";
+  }
+  const apiError = err && err.response && err.response.data;
+  if (apiError && (apiError.details || apiError.error)) {
+    return apiError.details || apiError.error;
+  }
+  return (err && err.message) || fallback;
+};
+
+// Create and register a new passkey for the given (already signed-up) user.
+export const registerPasskey = async (userId, name) => {
+  try {
+    const { data } = await axios.post(
+      `${API_BASE_URL}/passkey/register/options`,
+      { userId },
+    );
+    const attestation = await startRegistration({ optionsJSON: data.options });
+    const { data: verified } = await axios.post(
+      `${API_BASE_URL}/passkey/register/verify`,
+      { userId, flowId: data.flowId, name, response: attestation },
+    );
+    return verified.passkey;
+  } catch (err) {
+    throw new Error(friendlyError(err, "Could not create a passkey."));
+  }
+};
+
+// Authenticate with a passkey. Omitting `email` uses a discoverable
+// (usernameless) flow. Returns { customToken, userId, email }.
+export const authenticateWithPasskey = async (email) => {
+  try {
+    const { data } = await axios.post(
+      `${API_BASE_URL}/passkey/authenticate/options`,
+      email ? { email } : {},
+    );
+    const assertion = await startAuthentication({ optionsJSON: data.options });
+    const { data: verified } = await axios.post(
+      `${API_BASE_URL}/passkey/authenticate/verify`,
+      { flowId: data.flowId, response: assertion },
+    );
+    return verified;
+  } catch (err) {
+    throw new Error(friendlyError(err, "Passkey sign-in failed."));
+  }
+};
+
+// Fetch every passkey owned by the user.
+export const listPasskeys = async (userId) => {
+  const { data } = await axios.get(`${API_BASE_URL}/passkeys/${userId}`);
+  return data.passkeys || [];
+};
+
+// Rename a passkey.
+export const renamePasskey = async (userId, credentialId, name) => {
+  const { data } = await axios.patch(
+    `${API_BASE_URL}/passkeys/${userId}/${encodeURIComponent(credentialId)}`,
+    { name },
+  );
+  return data.passkey;
+};
+
+// Delete a passkey.
+export const deletePasskey = async (userId, credentialId) => {
+  await axios.delete(
+    `${API_BASE_URL}/passkeys/${userId}/${encodeURIComponent(credentialId)}`,
+  );
+};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -642,6 +642,164 @@ paths:
           description: Summary refined successfully
         400:
           description: Invalid input
+  /passkey/register/options:
+    post:
+      summary: Begin passkey registration
+      description: Generate WebAuthn registration options (a challenge) for the signed-in user. Returns a flowId that must be echoed back on verify.
+      operationId: getPasskeyRegistrationOptions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: string
+              required:
+                - userId
+      responses:
+        200:
+          description: Registration options generated
+        404:
+          description: User not found
+  /passkey/register/verify:
+    post:
+      summary: Complete passkey registration
+      description: Verify the authenticator attestation and store the new credential.
+      operationId: verifyPasskeyRegistration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: string
+                flowId:
+                  type: string
+                name:
+                  type: string
+                response:
+                  type: object
+                  description: The RegistrationResponseJSON produced by the browser.
+              required:
+                - userId
+                - flowId
+                - response
+      responses:
+        201:
+          description: Passkey registered successfully
+        400:
+          description: Verification failed or session expired
+        409:
+          description: Passkey already registered
+  /passkey/authenticate/options:
+    post:
+      summary: Begin passkey authentication
+      description: Generate WebAuthn authentication options. Provide an email to scope to that account's credentials, or omit it for a discoverable (usernameless) flow.
+      operationId: getPasskeyAuthenticationOptions
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+      responses:
+        200:
+          description: Authentication options generated
+  /passkey/authenticate/verify:
+    post:
+      summary: Complete passkey authentication
+      description: Verify the authenticator assertion and, on success, return a Firebase custom token and userId (the same contract as /login).
+      operationId: verifyPasskeyAuthentication
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                flowId:
+                  type: string
+                response:
+                  type: object
+                  description: The AuthenticationResponseJSON produced by the browser.
+              required:
+                - flowId
+                - response
+      responses:
+        200:
+          description: Authentication successful; returns customToken and userId
+        401:
+          description: Passkey not recognized or verification failed
+  /passkeys/{userId}:
+    get:
+      summary: List a user's passkeys
+      operationId: listPasskeys
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Passkeys retrieved successfully
+  /passkeys/{userId}/{credentialId}:
+    patch:
+      summary: Rename a passkey
+      operationId: renamePasskey
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: credentialId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+              required:
+                - name
+      responses:
+        200:
+          description: Passkey renamed
+        404:
+          description: Passkey not found
+    delete:
+      summary: Delete a passkey
+      operationId: deletePasskey
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: credentialId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Passkey deleted
+        404:
+          description: Passkey not found
 components:
   schemas:
     User:
@@ -669,3 +827,31 @@ components:
           type: string
         code:
           type: integer
+    Passkey:
+      type: object
+      description: A registered WebAuthn passkey (public metadata only; the public key is never returned).
+      properties:
+        id:
+          type: string
+          description: The credential ID (base64url), used as the document key.
+        name:
+          type: string
+        deviceType:
+          type: string
+          enum:
+            - singleDevice
+            - multiDevice
+        backedUp:
+          type: boolean
+          description: Whether the credential is synced/backed up across the user's devices.
+        transports:
+          type: array
+          items:
+            type: string
+        createdAt:
+          type: string
+          format: date-time
+        lastUsedAt:
+          type: string
+          format: date-time
+          nullable: true


### PR DESCRIPTION
## Overview

Adds end-to-end **passkey (WebAuthn)** support so users can register multiple passkeys, manage them on a dedicated page, and sign in password-free. Built to plug directly into the existing Firebase custom-token auth flow — passkey login returns the same `{ customToken, userId }` contract as `/login`, so the client's `setAuth(token, userId)` path is unchanged.

## Backend (`backend/`)

Uses [`@simplewebauthn/server@13`](https://simplewebauthn.dev/) for all cryptographic verification. Credentials and short-lived challenges are stored in Firestore alongside existing user data.

New endpoints (`controllers/passkeyController.js`, `models/passkeyModel.js`, wired in `index.js`):

| Method | Route | Purpose |
| --- | --- | --- |
| `POST` | `/passkey/register/options` | Begin registration (excludes already-enrolled credentials) |
| `POST` | `/passkey/register/verify` | Verify attestation, store credential |
| `POST` | `/passkey/authenticate/options` | Begin auth (usernameless or email-scoped) |
| `POST` | `/passkey/authenticate/verify` | Verify assertion → Firebase custom token |
| `GET` | `/passkeys/:userId` | List a user's passkeys |
| `PATCH` | `/passkeys/:userId/:credentialId` | Rename |
| `DELETE` | `/passkeys/:userId/:credentialId` | Delete |

- Multiple passkeys per user, signature-counter replay protection, ownership checks on rename/delete.
- RP ID / origin derive from the request `Origin` by default; pin for production via `WEBAUTHN_RP_ID` / `WEBAUTHN_ORIGINS` / `WEBAUTHN_RP_NAME` (documented in `.env.example`).
- Swagger JSDoc added for every endpoint (registered in `swagger/swagger.js`).

## Frontend (`frontend/`)

- **New `/passkeys` page** (auth-guarded): add / rename / delete passkeys, "Synced vs This device" badges, empty + unsupported states — all themed MUI dialogs, **no native browser alerts/prompts**.
- **Post-signup modal** (`PasskeyPromptModal`) inviting new users to create their first passkey.
- **"Sign in with a passkey"** button on the Login page (discoverable + email flows).
- **Account dropdown** replaces the signed-in Logout button → **Passkeys** + **Log Out** (Log Out kept destructive-red); the mobile drawer gains a Passkeys entry.
- `@simplewebauthn/browser@13` wrapper in `utils/passkeys.js`; API origin centralized in `utils/api.js` (overridable via `REACT_APP_API_BASE_URL`).

## Testing

- **Backend:** 19/19 Jest tests pass, including 10 new passkey-controller tests (register/verify, auth/verify, list/rename/delete, ownership + duplicate guards).
- **Frontend:** 35/35 tests pass; production build compiles clean with no warnings.
- ⚠️ The live WebAuthn ceremony (real platform/hardware authenticator) was **not** exercised in CI — please smoke-test create/login on a real device.

## Notes

`CLAUDE.md` marks `backend/` and `frontend/` as "do not modify"; both were changed here because the feature inherently requires it (frontend UI was explicitly requested, and backend placement was confirmed as the integration point for the existing Firebase auth). No existing endpoints or auth contracts were altered.

https://claude.ai/code/session_01RVS684UNSe5k6vkMmuK22X

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVS684UNSe5k6vkMmuK22X)_