### PR TITLE
feat(orchestrator): per-client token-bucket rate limiter for LLM routes

### DIFF
--- a/orchestrator/.env.example
+++ b/orchestrator/.env.example
@@ -19,6 +19,10 @@ MONTHLY_BUDGET=200
 CIRCUIT_BREAKER_THRESHOLD=3
 CIRCUIT_BREAKER_COOLDOWN_MS=60000
 
+# Rate Limiting (per-client token bucket on the LLM-backed routes)
+RATE_LIMIT_CAPACITY=60
+RATE_LIMIT_REFILL_PER_SEC=1
+
 # Redis (for Hybrid RAG keyword search)
 REDIS_URL=redis://localhost:6379
 

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -97,6 +97,10 @@ AI_ML_SERVICE_URL=http://localhost:8000
 CIRCUIT_BREAKER_THRESHOLD=3
 CIRCUIT_BREAKER_COOLDOWN_MS=60000
 
+# Rate limiting (per-client token bucket on LLM-backed routes)
+RATE_LIMIT_CAPACITY=60
+RATE_LIMIT_REFILL_PER_SEC=1
+
 # Cost budgets (USD)
 DAILY_BUDGET=10
 MONTHLY_BUDGET=200
@@ -179,6 +183,21 @@ Full system health report.
   "gemini": { "state": "CLOSED", "failures": 0, "uptime": "98.5%" }
 }
 ```
+
+### `GET /api/rate-limit`
+
+Current token-bucket rate-limiter configuration and the number of active client buckets.
+
+**Response:**
+```json
+{
+  "activeKeys": 3,
+  "capacity": 60,
+  "refillPerSec": 1
+}
+```
+
+The expensive LLM-backed routes (`/api/supervisor/process`, `/api/agent/run`, `/api/batch/process`) are guarded by a per-client token bucket. Each response carries `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers; when the bucket is empty the route returns **`429 Too Many Requests`** with a `Retry-After` header and `{ "error": "Rate limit exceeded", "retryAfterMs": <ms> }`. Tune with `RATE_LIMIT_CAPACITY` / `RATE_LIMIT_REFILL_PER_SEC`.
 
 ### `POST /api/supervisor/process`
 

--- a/orchestrator/__tests__/rate-limiter.test.js
+++ b/orchestrator/__tests__/rate-limiter.test.js
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for the token-bucket RateLimiter and its Express middleware.
+ * Run: cd orchestrator && npx jest rate-limiter --no-cache
+ *
+ * A controllable `now()` clock is injected so refill behavior is deterministic
+ * (no real timers / sleeps).
+ */
+
+const { RateLimiter, rateLimitMiddleware } = require("../core/rate-limiter");
+
+// Minimal Express res/next stubs so the middleware can be exercised in isolation.
+function makeRes() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: undefined,
+    set(key, value) {
+      this.headers[key] = String(value);
+      return this;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+// ============ RateLimiter ============
+describe("RateLimiter", () => {
+  let clock;
+  const now = () => clock;
+
+  beforeEach(() => {
+    clock = 1_000;
+  });
+
+  test("allows requests up to capacity then blocks", () => {
+    const rl = new RateLimiter({ capacity: 3, refillPerSec: 1, now });
+    expect(rl.tryConsume("a").allowed).toBe(true);
+    expect(rl.tryConsume("a").allowed).toBe(true);
+    expect(rl.tryConsume("a").allowed).toBe(true);
+    expect(rl.tryConsume("a").allowed).toBe(false);
+  });
+
+  test("reports remaining tokens and the limit", () => {
+    const rl = new RateLimiter({ capacity: 5, refillPerSec: 1, now });
+    const first = rl.tryConsume("a");
+    expect(first.limit).toBe(5);
+    expect(first.remaining).toBe(4);
+    expect(rl.tryConsume("a").remaining).toBe(3);
+  });
+
+  test("a blocked request reports a positive retryAfterMs", () => {
+    const rl = new RateLimiter({ capacity: 1, refillPerSec: 1, now });
+    rl.tryConsume("a"); // drains the bucket
+    const blocked = rl.tryConsume("a");
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.retryAfterMs).toBe(1000); // 1 token / 1 per sec
+  });
+
+  test("refills tokens over time at refillPerSec", () => {
+    const rl = new RateLimiter({ capacity: 5, refillPerSec: 1, now });
+    for (let i = 0; i < 5; i++) rl.tryConsume("a"); // drain
+    expect(rl.tryConsume("a").allowed).toBe(false);
+
+    clock += 2_000; // 2 seconds → +2 tokens
+    const after = rl.tryConsume("a");
+    expect(after.allowed).toBe(true);
+    expect(after.remaining).toBe(1);
+  });
+
+  test("refill never exceeds capacity", () => {
+    const rl = new RateLimiter({ capacity: 3, refillPerSec: 10, now });
+    rl.tryConsume("a"); // tokens: 2
+    clock += 60_000; // would add 600 tokens, but caps at capacity
+    expect(rl.getState("a").tokens).toBe(3);
+  });
+
+  test("keeps a separate bucket per key", () => {
+    const rl = new RateLimiter({ capacity: 1, refillPerSec: 1, now });
+    expect(rl.tryConsume("a").allowed).toBe(true);
+    expect(rl.tryConsume("a").allowed).toBe(false);
+    // A different key is unaffected.
+    expect(rl.tryConsume("b").allowed).toBe(true);
+  });
+
+  test("supports a cost greater than one", () => {
+    const rl = new RateLimiter({ capacity: 10, refillPerSec: 1, now });
+    const r = rl.tryConsume("a", 4);
+    expect(r.allowed).toBe(true);
+    expect(r.remaining).toBe(6);
+    // Not enough tokens for a cost of 7 → blocked, bucket unchanged.
+    const blocked = rl.tryConsume("a", 7);
+    expect(blocked.allowed).toBe(false);
+    expect(rl.getState("a").tokens).toBe(6);
+  });
+
+  test("getState returns a full bucket for an unknown key", () => {
+    const rl = new RateLimiter({ capacity: 4, refillPerSec: 1, now });
+    expect(rl.getState("never-seen")).toEqual({ tokens: 4, capacity: 4 });
+  });
+
+  test("reset restores a single key; resetAll clears every bucket", () => {
+    const rl = new RateLimiter({ capacity: 1, refillPerSec: 1, now });
+    rl.tryConsume("a");
+    rl.tryConsume("b");
+    rl.reset("a");
+    expect(rl.tryConsume("a").allowed).toBe(true); // refilled
+    expect(rl.tryConsume("b").allowed).toBe(false); // still drained
+
+    rl.resetAll();
+    expect(rl.getStats().activeKeys).toBe(0);
+  });
+
+  test("getStats reports active keys and configuration", () => {
+    const rl = new RateLimiter({ capacity: 7, refillPerSec: 2, now });
+    rl.tryConsume("a");
+    rl.tryConsume("b");
+    expect(rl.getStats()).toEqual({
+      activeKeys: 2,
+      capacity: 7,
+      refillPerSec: 2,
+    });
+  });
+
+  test("rejects invalid configuration", () => {
+    expect(() => new RateLimiter({ capacity: 0 })).toThrow();
+    expect(() => new RateLimiter({ capacity: 5, refillPerSec: 0 })).toThrow();
+  });
+});
+
+// ============ rateLimitMiddleware ============
+describe("rateLimitMiddleware", () => {
+  let clock;
+  const now = () => clock;
+
+  beforeEach(() => {
+    clock = 1_000;
+  });
+
+  test("allows a request, sets rate-limit headers, and calls next", () => {
+    const rl = new RateLimiter({ capacity: 2, refillPerSec: 1, now });
+    const mw = rateLimitMiddleware(rl);
+    const req = { ip: "1.2.3.4" };
+    const res = makeRes();
+    let nextCalled = false;
+
+    mw(req, res, () => {
+      nextCalled = true;
+    });
+
+    expect(nextCalled).toBe(true);
+    expect(res.headers["X-RateLimit-Limit"]).toBe("2");
+    expect(res.headers["X-RateLimit-Remaining"]).toBe("1");
+  });
+
+  test("blocks with 429, Retry-After, and does not call next", () => {
+    const rl = new RateLimiter({ capacity: 1, refillPerSec: 1, now });
+    const mw = rateLimitMiddleware(rl);
+    const req = { ip: "1.2.3.4" };
+    let nextCount = 0;
+    const next = () => {
+      nextCount += 1;
+    };
+
+    mw(req, makeRes(), next); // consumes the only token
+    const res = makeRes();
+    mw(req, res, next); // blocked
+
+    expect(nextCount).toBe(1);
+    expect(res.statusCode).toBe(429);
+    expect(res.headers["Retry-After"]).toBe("1");
+    expect(res.body.error).toMatch(/rate limit/i);
+    expect(res.body.retryAfterMs).toBe(1000);
+  });
+
+  test("derives the bucket key from a custom keyFn", () => {
+    const rl = new RateLimiter({ capacity: 1, refillPerSec: 1, now });
+    const mw = rateLimitMiddleware(rl, {
+      keyFn: (req) => req.body.userId,
+    });
+
+    let blocked = false;
+    mw({ body: { userId: "u1" } }, makeRes(), () => {});
+    mw({ body: { userId: "u1" } }, makeRes(), () => {
+      blocked = true;
+    });
+    expect(blocked).toBe(false); // second u1 call was blocked → next not called
+
+    // A different user has an independent bucket.
+    let allowed = false;
+    mw({ body: { userId: "u2" } }, makeRes(), () => {
+      allowed = true;
+    });
+    expect(allowed).toBe(true);
+  });
+});

--- a/orchestrator/core/rate-limiter.js
+++ b/orchestrator/core/rate-limiter.js
@@ -1,0 +1,126 @@
+/**
+ * Token-bucket rate limiter.
+ *
+ * Sits alongside the other reliability primitives (circuit breaker, cost
+ * tracker, dead-letter queue) and protects the orchestrator's expensive
+ * LLM-backed routes from runaway usage / abuse. Each key (by default the client
+ * IP) gets its own bucket that holds up to `capacity` tokens and refills at
+ * `refillPerSec`. A request consumes `cost` tokens; if the bucket can't cover
+ * the cost the request is rejected with the time until enough tokens refill.
+ *
+ * The clock is injectable (`now`) so behavior is fully deterministic in tests.
+ */
+class RateLimiter {
+  constructor({ capacity = 60, refillPerSec = 1, now } = {}) {
+    if (!Number.isFinite(capacity) || capacity <= 0) {
+      throw new Error("RateLimiter: capacity must be a positive number");
+    }
+    if (!Number.isFinite(refillPerSec) || refillPerSec <= 0) {
+      throw new Error("RateLimiter: refillPerSec must be a positive number");
+    }
+    this.capacity = capacity;
+    this.refillPerSec = refillPerSec;
+    this.now = now || (() => Date.now());
+    this.buckets = new Map(); // key -> { tokens, lastRefill }
+  }
+
+  // Lazily creates a bucket (full) and brings its token count up to `now`.
+  _refill(key) {
+    const ts = this.now();
+    let bucket = this.buckets.get(key);
+    if (!bucket) {
+      bucket = { tokens: this.capacity, lastRefill: ts };
+      this.buckets.set(key, bucket);
+      return bucket;
+    }
+    const elapsedSec = (ts - bucket.lastRefill) / 1000;
+    if (elapsedSec > 0) {
+      bucket.tokens = Math.min(
+        this.capacity,
+        bucket.tokens + elapsedSec * this.refillPerSec,
+      );
+      bucket.lastRefill = ts;
+    }
+    return bucket;
+  }
+
+  /**
+   * Attempt to consume `cost` tokens for `key`.
+   * @returns {{allowed: boolean, remaining: number, limit: number, retryAfterMs: number}}
+   */
+  tryConsume(key, cost = 1) {
+    const bucket = this._refill(key);
+    if (bucket.tokens >= cost) {
+      bucket.tokens -= cost;
+      return {
+        allowed: true,
+        remaining: bucket.tokens,
+        limit: this.capacity,
+        retryAfterMs: 0,
+      };
+    }
+    const deficit = cost - bucket.tokens;
+    return {
+      allowed: false,
+      remaining: bucket.tokens,
+      limit: this.capacity,
+      retryAfterMs: Math.ceil((deficit / this.refillPerSec) * 1000),
+    };
+  }
+
+  /** Current token count for a key (refilled to now). Unknown keys read full. */
+  getState(key) {
+    if (!this.buckets.has(key)) {
+      return { tokens: this.capacity, capacity: this.capacity };
+    }
+    const bucket = this._refill(key);
+    return { tokens: bucket.tokens, capacity: this.capacity };
+  }
+
+  /** Forget a single key's bucket (it will read as full again). */
+  reset(key) {
+    this.buckets.delete(key);
+  }
+
+  /** Forget every bucket. */
+  resetAll() {
+    this.buckets.clear();
+  }
+
+  getStats() {
+    return {
+      activeKeys: this.buckets.size,
+      capacity: this.capacity,
+      refillPerSec: this.refillPerSec,
+    };
+  }
+}
+
+/**
+ * Express middleware factory backed by a {@link RateLimiter}.
+ *
+ * @param {RateLimiter} limiter
+ * @param {object}   [options]
+ * @param {(req)=>string} [options.keyFn]  derive the bucket key (default: req.ip)
+ * @param {number}        [options.cost=1] tokens this route consumes
+ */
+function rateLimitMiddleware(limiter, { keyFn, cost = 1 } = {}) {
+  return (req, res, next) => {
+    const key = (keyFn ? keyFn(req) : req.ip) || "global";
+    const result = limiter.tryConsume(key, cost);
+
+    res.set("X-RateLimit-Limit", result.limit);
+    res.set("X-RateLimit-Remaining", Math.max(0, Math.floor(result.remaining)));
+
+    if (!result.allowed) {
+      res.set("Retry-After", Math.ceil(result.retryAfterMs / 1000));
+      return res.status(429).json({
+        error: "Rate limit exceeded",
+        retryAfterMs: result.retryAfterMs,
+      });
+    }
+    return next();
+  };
+}
+
+module.exports = { RateLimiter, rateLimitMiddleware };

--- a/orchestrator/index.js
+++ b/orchestrator/index.js
@@ -11,6 +11,7 @@ const { BatchProcessor } = require("./core/batch-processor");
 const { AgentLoop } = require("./core/agent-loop");
 const { HandoffManager } = require("./core/handoff");
 const { DeadLetterQueue } = require("./core/dlq");
+const { RateLimiter, rateLimitMiddleware } = require("./core/rate-limiter");
 const { DocuThinkerSupervisor } = require("./core/supervisor");
 const { TokenBudgetManager } = require("./context/token-budget");
 const { ConversationStore } = require("./context/conversation-store");
@@ -38,6 +39,13 @@ const conversationStore = new ConversationStore({ tokenBudget, llmClient });
 const contextObservability = new ContextObservability();
 const promptCache = new PromptCacheStrategy();
 const dlq = new DeadLetterQueue({ maxRetries: 3 });
+// Per-client token bucket guarding the expensive LLM-backed routes. Defaults to
+// 60 requests with a 1 req/s sustained refill; override via env.
+const rateLimiter = new RateLimiter({
+  capacity: parseInt(process.env.RATE_LIMIT_CAPACITY || "60", 10),
+  refillPerSec: parseFloat(process.env.RATE_LIMIT_REFILL_PER_SEC || "1"),
+});
+const llmRateLimit = rateLimitMiddleware(rateLimiter);
 const toolRegistry = new ToolRegistry({ pythonBridge });
 toolRegistry.registerStandardTools();
 const batchProcessor = new BatchProcessor({ llmClient, costTracker });
@@ -160,6 +168,7 @@ app.get("/health", async (req, res) => {
       contextObservability: contextObservability.getStats(),
       conversations: { active: conversationStore.getConversationCount() },
       dlq: dlq.getStats(),
+      rateLimit: rateLimiter.getStats(),
       providers: llmClient.getAvailableProviders(),
       tools: toolRegistry.getToolNames(),
     });
@@ -172,6 +181,7 @@ app.get("/api/costs", (req, res) =>
   res.json(costTracker.getUsageReport(req.query.period || "month")),
 );
 app.get("/api/circuits", (req, res) => res.json(circuitBreaker.getStatus()));
+app.get("/api/rate-limit", (req, res) => res.json(rateLimiter.getStats()));
 app.get("/api/context-metrics", (req, res) =>
   res.json(contextObservability.getStats()),
 );
@@ -205,7 +215,7 @@ app.post("/api/token-check", (req, res) => {
   }
 });
 
-app.post("/api/supervisor/process", async (req, res) => {
+app.post("/api/supervisor/process", llmRateLimit, async (req, res) => {
   try {
     const result = await supervisor.process({
       route: req.body.route || null,
@@ -217,7 +227,7 @@ app.post("/api/supervisor/process", async (req, res) => {
   }
 });
 
-app.post("/api/agent/run", async (req, res) => {
+app.post("/api/agent/run", llmRateLimit, async (req, res) => {
   try {
     const { systemPrompt, message, context, provider } = req.body;
     if (!message) return res.status(400).json({ error: "message is required" });
@@ -235,7 +245,7 @@ app.post("/api/agent/run", async (req, res) => {
   }
 });
 
-app.post("/api/batch/process", async (req, res) => {
+app.post("/api/batch/process", llmRateLimit, async (req, res) => {
   try {
     const { documents, operation, provider } = req.body;
     if (!documents || !Array.isArray(documents) || documents.length === 0)


### PR DESCRIPTION
## Summary

Adds a **token-bucket rate limiter** to the orchestrator — a new reliability primitive that sits alongside the existing circuit breaker, cost tracker, and dead-letter queue. It guards the expensive LLM-backed routes from runaway usage / abuse (which directly maps to API spend), per client.

## What's included

**`core/rate-limiter.js`**
- `RateLimiter` — per-key token buckets with configurable `capacity` and `refillPerSec`. The clock is **injectable** (`now`) so refill behavior is fully deterministic in tests (no real timers/sleeps). API: `tryConsume(key, cost)`, `getState(key)`, `reset(key)`, `resetAll()`, `getStats()`; validates its config.
- `rateLimitMiddleware(limiter, { keyFn, cost })` — Express factory that sets `X-RateLimit-Limit` / `X-RateLimit-Remaining` on every response and, when a bucket is empty, returns **`429 Too Many Requests`** with a `Retry-After` header and `{ error, retryAfterMs }`.

**`index.js` wiring**
- Guards the three expensive routes: `/api/supervisor/process`, `/api/agent/run`, `/api/batch/process` (keyed by client IP).
- New **`GET /api/rate-limit`** stats route; rate-limit stats also surfaced in `/health`.
- Tunable via `RATE_LIMIT_CAPACITY` (default 60) and `RATE_LIMIT_REFILL_PER_SEC` (default 1).

**Docs**: `README.md` (new endpoint section + env) and `.env.example`.

## Testing (TDD)

Built test-first (red → green). **14 new unit tests** cover capacity limits, time-based refill + cap, per-key isolation, `cost > 1`, reset/resetAll, stats, config validation, and the middleware (headers, 429 + Retry-After, custom `keyFn`).

```
Test Suites: 2 passed, 2 total
Tests:       116 passed, 116 total   (102 existing + 14 new)
```

## Notes
- In-memory by design (single-instance orchestrator); a Redis-backed store could be swapped in later behind the same interface if the orchestrator is horizontally scaled.
- Scope limited to `orchestrator/` per the project's module conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)