### PR TITLE
feat: integrate Sentry monitoring across frontend and backend

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -233,6 +233,7 @@ graph TB
         GRAF[Grafana<br/>Visualization]
         JAEGER[Jaeger<br/>Trace Analysis]
         ELK[ELK Stack<br/>Log Aggregation]
+        SENTRY[Sentry<br/>Errors + Replay + APM]
     end
 
     subgraph "Reliability Engineering"
@@ -269,6 +270,8 @@ graph TB
     OTEL --> PROM
     PROM --> GRAF
     BE -.->|Logs| ELK
+    FE -.->|Errors + Replay| SENTRY
+    BE -.->|Errors + Traces| SENTRY
 
     LITMUS -.->|Test| BE
     FLAGGER -.->|Canary| BE
@@ -337,9 +340,11 @@ graph TB
             S[Error Handling]
             T[Form Validation]
             U[Date Formatting]
+            SENT[Sentry<br/>ErrorBoundary + Replay + Tracing]
         end
     end
 
+    A --> SENT
     A --> B
     B --> C
     B --> D
@@ -366,6 +371,8 @@ graph TB
     N --> P
     O --> P
 ```
+
+**Error & session monitoring.** Sentry (`@sentry/react`) is initialized in `src/sentry.js`, which is imported **first** in `index.js` so `Sentry.init()` runs before React renders. The app tree is wrapped in `Sentry.ErrorBoundary`, so uncaught render errors are reported with a graceful fallback UI. The SDK also captures **browser performance traces** (`browserTracingIntegration`) and **session replays** (`replayIntegration`, 100% of errored sessions), and `tracePropagationTargets` propagates trace headers to the backend API so a browser transaction stitches to its backend spans. DSN and sample rates are configurable via `REACT_APP_SENTRY_*` env vars.
 
 ---
 
@@ -519,6 +526,7 @@ The backend follows the **MVC (Model-View-Controller)** pattern with additional 
 - **Raised JSON/urlencoded body limit** — `express.json({ limit: "25mb" })` (and the matching `urlencoded` limit), up from body-parser's ~100 KB default. The `/upload` body now carries the extracted **text + display HTML** for large documents; the **original file itself bypasses the backend entirely** (it goes straight to Supabase), so this limit only needs to cover the extracted payload.
 - **Structured request/response logging** — a paired `[REQ] METHOD url` on entry and `[RES] METHOD url -> status (Nms)` on `finish`, so every call is traceable in Vercel logs (5xx logged at `error` level).
 - **Layered error handling** — a global error handler, an `UnauthorizedError` handler, and a catch-all `[UNHANDLED]` handler that logs a full stack (skipping if headers are already sent) instead of a silent 500.
+- **Sentry monitoring** — `./instrument` is required at the **very top** of `index.js` (before any other module) so `@sentry/node` can auto-instrument Express/HTTP at require-time. `Sentry.setupExpressErrorHandler(app)` is registered **after all routes and before** the custom error handlers, so unhandled route errors are captured and forwarded to Sentry. Performance tracing, CPU profiling (`@sentry/profiling-node`), and structured logs are enabled; DSN and sample rates are configurable via `SENTRY_*` env vars.
 - **Process-level crash loggers** — `unhandledRejection` and `uncaughtException` listeners so crashes are never silent.
 - **Surfaces** — REST routes, **GraphQL at `/graphql`** (GraphiQL enabled), **Swagger UI at `/api-docs`** (served from CDN, JSON at `/swagger.json`), and the **Passkey/WebAuthn** routes.
 
@@ -534,6 +542,7 @@ graph TB
             D[Firebase Auth Middleware]
             E[Error Handlers<br/>global + Unauthorized + UNHANDLED]
             F[Req/Res Logger]
+            SEN[Sentry<br/>instrument + error handler]
         end
 
         subgraph "Routes Layer"

--- a/DEVOPS.md
+++ b/DEVOPS.md
@@ -37,7 +37,7 @@ DocuThinker uses a modern, enterprise-grade cloud-native architecture with **16 
 - **Infrastructure as Code**: Terraform + Helm
 - **CI/CD**: GitLab CI / GitHub Actions / Jenkins
 - **GitOps**: ArgoCD
-- **Observability**: OpenTelemetry + Prometheus + Grafana + Jaeger + ELK + **Coralogix**
+- **Observability**: OpenTelemetry + Prometheus + Grafana + Jaeger + ELK + **Coralogix** (infrastructure) · **Sentry** (application APM)
 - **Chaos Engineering**: Litmus 3.0
 - **Progressive Delivery**: Flagger 1.34
 - **Backup & DR**: Velero 1.12 (RTO < 1 hour)
@@ -878,6 +878,19 @@ cd terraform && terraform apply -target=module.coralogix
 ```
 
 **12 Production Alerts**: High error rate, P95 latency, pod crashlooping, memory/CPU usage, DB pool exhaustion, API endpoint down, error budget burn, node health, disk space, SLO violations, Redis memory.
+
+---
+
+### Sentry — Application Performance Monitoring (APM)
+
+Where the Prometheus / OTel / Coralogix stack instruments the **infrastructure** (nodes, pods, service mesh), **Sentry** provides **application-level** error monitoring wired directly into the app code — a complementary layer, not a replacement. It requires no K8s deployment; the SDKs initialize at process/bundle startup.
+
+| Layer | SDK | Init | Captures |
+|-------|-----|------|----------|
+| Frontend (React) | `@sentry/react` | `frontend/src/sentry.js` (imported first in `index.js`) | Uncaught render errors (via `Sentry.ErrorBoundary`), browser performance traces, session replay |
+| Backend (Express) | `@sentry/node` + `@sentry/profiling-node` | `backend/instrument.js` (required before any other module) | Unhandled route errors (via `setupExpressErrorHandler`), transaction traces, CPU profiles, structured logs |
+
+**Distributed tracing** — the frontend sets `tracePropagationTargets` to the backend API origin, so a browser transaction stitches to its backend spans inside Sentry. DSN and sample rates are env-configurable (`SENTRY_DSN` / `REACT_APP_SENTRY_DSN`); sample rates tighten automatically in production.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ DocuThinker is built with **120+ technologies** spanning frontend, backend, AI/M
   - **Coralogix**: Unified SaaS observability platform with TCO optimization — receives logs, metrics, and traces via OTel OTLP/gRPC; Fluent Bit DaemonSet for node-level log shipping; Prometheus remote write for metric correlation; 12 production alerts; recording rules; TCO cost policies; Terraform-managed via `coralogix/coralogix` provider.
   - **AlertManager**: Alert routing with Slack and PagerDuty integrations.
   - **SLI/SLO Monitoring**: Prometheus recording rules for availability and latency tracking.
+  - **Sentry**: Application-level error monitoring, performance tracing, session replay, and structured logs across the React frontend (`@sentry/react`) and Express backend (`@sentry/node` + profiling). Distributed tracing links browser transactions to backend spans via `tracePropagationTargets`, and the frontend `Sentry.ErrorBoundary` reports uncaught React render errors.
 - **Security & Compliance**:
   - **HashiCorp Vault 1.15**: Secrets management with HA Raft storage, AWS KMS seal, CSI provider.
   - **External Secrets Operator**: Syncs secrets from Vault and AWS Secrets Manager into Kubernetes.
@@ -489,6 +490,7 @@ DocuThinker is built with **120+ technologies** spanning frontend, backend, AI/M
   <img src="https://img.shields.io/badge/Kibana-005571?style=for-the-badge&logo=kibana&logoColor=white" alt="Kibana" />
   <img src="https://img.shields.io/badge/AlertManager-E6522C?style=for-the-badge&logo=prometheus&logoColor=white" alt="AlertManager" />
   <img src="https://img.shields.io/badge/Coralogix-6C63FF?style=for-the-badge&logo=datadog&logoColor=white" alt="Coralogix" />
+  <img src="https://img.shields.io/badge/Sentry-362D59?style=for-the-badge&logo=sentry&logoColor=white" alt="Sentry" />
 
   <!-- 🔒 Security & Compliance -->
   <img src="https://img.shields.io/badge/Vault-FFEC6E?style=for-the-badge&logo=vault&logoColor=black" alt="Vault" />
@@ -912,6 +914,8 @@ The backend and frontend each read from their own `.env` file (both git-ignored)
 | `SUPABASE_SERVICE_ROLE_KEY` | Server-side Supabase key for signing upload/download URLs and storing content (never exposed to the browser).                                                         |
 | `SUPABASE_BUCKET`           | Storage bucket name (defaults to `docuthinker`).                                                                                                                      |
 | `REDIS_*`                   | Redis connection config for caching.                                                                                                                                  |
+| `SENTRY_DSN`                | Sentry DSN for backend error, performance, and log monitoring (optional; falls back to the hosted project DSN).                                                      |
+| `SENTRY_RELEASE`            | Release identifier attached to Sentry events (optional, e.g. git SHA).                                                                                               |
 
 **Frontend (`frontend/.env`)**
 
@@ -923,6 +927,9 @@ The backend and frontend each read from their own `.env` file (both git-ignored)
 | `REACT_APP_GOOGLE_DRIVE_API_KEY`   | Google Drive Picker API key.                         |
 | `REACT_APP_GOOGLE_DRIVE_CLIENT_ID` | Google OAuth client ID for Drive import.             |
 | `REACT_APP_API_BASE_URL`           | Base URL of the backend API.                         |
+| `REACT_APP_SENTRY_DSN`             | Sentry DSN for browser error, tracing, and session-replay monitoring (optional; falls back to the hosted project DSN). |
+| `REACT_APP_SENTRY_ENV`             | Sentry environment name (defaults to `NODE_ENV`).    |
+| `REACT_APP_SENTRY_RELEASE`         | Release identifier attached to Sentry events (optional). |
 
 > [!IMPORTANT]
 > Only the **service-role** Supabase key lives on the backend; the browser ever only sees the public **anon** key plus one-time, path-scoped signed upload tokens. Keep `SUPABASE_SERVICE_ROLE_KEY` and `firebase-admin-sdk.json` out of source control.

--- a/backend/README.md
+++ b/backend/README.md
@@ -44,6 +44,7 @@ The backend is deployed as a **Vercel serverless function** (the whole Express a
 | Passwordless auth | **Passkeys / WebAuthn** (`@simplewebauthn/server`) |
 | Multipart parsing | **`formidable`** (the fallback file-upload endpoint) |
 | Document parsing | **`pdf-parse`** (PDF), **`mammoth`** (DOCX) |
+| Monitoring | **Sentry** (`@sentry/node` + `@sentry/profiling-node`) — errors, performance tracing, profiling, and logs |
 
 The codebase follows an **MVC-style** layout: `controllers/` (REST handlers), `services/` (Firebase, Supabase, and Gemini integration), `views/` (response formatting), `graphql/` (schema + resolvers), and `models/` (passkey persistence).
 
@@ -58,6 +59,7 @@ The codebase follows an **MVC-style** layout: `controllers/` (REST handlers), `s
 - **Redis Caching** — utility helpers for sessions, document metadata, query results, and recently-viewed documents.
 - **Swagger / OpenAPI Documentation** — self-documenting API generated from JSDoc annotations.
 - **Structured Logging & Error Handling** — request/response logging, structured error logs, a global error handler, and process-level crash loggers.
+- **Sentry Monitoring** — error tracking, performance tracing, CPU profiling, and structured logs via `@sentry/node`, initialized in `instrument.js` before any other module so Express is auto-instrumented; unhandled route errors are captured by `Sentry.setupExpressErrorHandler`.
 
 ## Prerequisites
 
@@ -145,6 +147,15 @@ Defaults are derived from the request `Origin` header. Pin these for production 
 | `WEBAUTHN_ORIGINS` | Comma-separated list of expected origins (e.g. `https://docuthinker-fullstack-app.vercel.app`). |
 | `WEBAUTHN_RP_NAME` | Human-readable Relying Party name shown in the browser prompt (defaults to `DocuThinker`). |
 
+### Sentry (monitoring — optional)
+
+Sentry is initialized in `instrument.js`, which is required at the **very top** of `index.js` (before any other module) so `@sentry/node` can auto-instrument Express/HTTP. `Sentry.setupExpressErrorHandler(app)` captures unhandled route errors. Sample rates tighten automatically when `NODE_ENV=production`.
+
+| Variable | Description |
+| -------- | ----------- |
+| `SENTRY_DSN` | Sentry project DSN for backend error, performance, and log monitoring. If unset, a hosted DocuThinker project DSN is used as a fallback. |
+| `SENTRY_RELEASE` | Release identifier attached to Sentry events (e.g. a git SHA). Optional. |
+
 ### Example `.env`
 
 ```bash
@@ -176,6 +187,10 @@ REDIS_URL=rediss://default:password@host:port
 WEBAUTHN_RP_ID=docuthinker-fullstack-app.vercel.app
 WEBAUTHN_ORIGINS=https://docuthinker-fullstack-app.vercel.app
 WEBAUTHN_RP_NAME=DocuThinker
+
+# Sentry (monitoring — optional; falls back to the hosted project DSN)
+SENTRY_DSN=https://<key>@<org>.ingest.us.sentry.io/<project>
+SENTRY_RELEASE=
 ```
 
 ## Running the Server
@@ -226,6 +241,7 @@ The backend follows an **MVC-style** layout for separation of concerns:
 ```
 DocuThinker-AI-App/
 └── backend/
+    ├── instrument.js            # Sentry init — required first in index.js (auto-instruments Express)
     ├── index.js                 # Express app entry point: middleware, routes, GraphQL, Swagger
     ├── controllers/
     │   ├── controllers.js       # REST handlers (auth, documents, AI, account)

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,3 +1,7 @@
+// IMPORTANT: `./instrument` must be required before any other module so Sentry
+// can auto-instrument Express, HTTP, and other libraries at require-time.
+const Sentry = require("./instrument");
+
 const favicon = require("serve-favicon");
 const path = require("path");
 const express = require("express");
@@ -240,6 +244,10 @@ app.delete("/passkeys/:userId/:credentialId", deletePasskey);
 app.use((req, res) => {
   res.status(404).json({ error: "Route not found" });
 });
+
+// Sentry error handler: must be registered after all controllers/routes and
+// before any other error-handling middleware. Captures errors thrown in routes.
+Sentry.setupExpressErrorHandler(app);
 
 // Global error handler
 app.use((err, req, res, next) => {

--- a/backend/instrument.js
+++ b/backend/instrument.js
@@ -1,0 +1,49 @@
+// Sentry instrumentation for the DocuThinker backend.
+//
+// IMPORTANT: this file MUST be required at the very top of `index.js`, before
+// any other module is required. Sentry relies on auto-instrumentation that
+// patches libraries (Express, HTTP, etc.) at require-time, so `Sentry.init()`
+// has to run before those libraries are loaded.
+//
+// Configuration (env vars, falls back to the hosted DocuThinker project):
+//   SENTRY_DSN      - project DSN
+//   SENTRY_RELEASE  - release identifier (optional, e.g. git SHA)
+//   NODE_ENV        - environment name (production tightens sample rates)
+
+// Load env vars before reading them (index.js also calls this later; dotenv is idempotent).
+require("dotenv").config();
+
+const Sentry = require("@sentry/node");
+const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+
+const DEFAULT_DSN =
+  "https://56b62c1af91c6fef6e066237685aa8e2@o4511764618543104.ingest.us.sentry.io/4511764642856960";
+
+const dsn = process.env.SENTRY_DSN || DEFAULT_DSN;
+const environment = process.env.NODE_ENV || "development";
+const isProduction = environment === "production";
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment,
+    release: process.env.SENTRY_RELEASE || undefined,
+
+    // Profiling (CPU profiles for traced transactions).
+    integrations: [nodeProfilingIntegration()],
+
+    // Performance Monitoring: sample 100% of transactions in dev, 20% in prod.
+    tracesSampleRate: isProduction ? 0.2 : 1.0,
+
+    // Profiling sample rate is relative to tracesSampleRate.
+    profilesSampleRate: 1.0,
+
+    // Structured logs -> Sentry Logs.
+    enableLogs: true,
+
+    // Attach request data (headers, IP, etc.) to events.
+    sendDefaultPii: true,
+  });
+}
+
+module.exports = Sentry;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,8 @@
         "@graphql-tools/schema": "^10.0.16",
         "@graphql-tools/utils": "^10.7.2",
         "@mui/material": "^5.0.0",
+        "@sentry/node": "^10.66.0",
+        "@sentry/profiling-node": "^10.66.0",
         "@simplewebauthn/server": "^13.3.1",
         "@supabase/supabase-js": "^2.106.2",
         "axios": "^1.7.7",
@@ -111,6 +113,73 @@
       },
       "peerDependencies": {
         "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.0.tgz",
+      "integrity": "sha512-aN3Oq8r1J3gPJtCwErP664gM0+HhM1I1lujPr9TMTCcEl/joQQbpGpeMdts9B1+W2wHMsvioDMv5F4PvMWE6gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.6.2.tgz",
+      "integrity": "sha512-5vBrtIEL+UVbO0YWWoyYG4QMgR+ZfnIL3xlteIkAmU7YaAPhc28k3md/NM14tnkfXKjKOn9yUzEA9AYUmNpvJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@apollo/client": {
@@ -4116,9 +4185,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -4407,12 +4477,116 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "optional": true,
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/asn1-android": {
@@ -4846,6 +5020,151 @@
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
       "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA=="
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.66.0.tgz",
+      "integrity": "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.66.0.tgz",
+      "integrity": "sha512-5Ow7iQiRjaSaEOmqEIkYV368hFFzShIZCXPoj+wX3JtOmKFrsNu6lr8/VJlQs7cyjFS6tzE50PrLrD8iAPS/8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0",
+        "@sentry/node-core": "10.66.0",
+        "@sentry/opentelemetry": "10.66.0",
+        "@sentry/server-utils": "10.66.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.66.0.tgz",
+      "integrity": "sha512-SUnXHROqSdSetKgZC1goDEKCuMz3OmQ1h4rxzWeexLyqan+pensZXfLouP6jzZXlA8e/HP7uQg78LnfqYDcZlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0",
+        "@sentry/opentelemetry": "10.66.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/node-cpu-profiler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node-cpu-profiler/-/node-cpu-profiler-2.4.2.tgz",
+      "integrity": "sha512-E6q+eE/sTpiofzW9jFKAx6ZQaDAoZDnsaLA/nRlkiK+K2X4k+hSyKhhLfw8PJlejB8edk7uxJF57r5JoRnyaPA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "node-abi": "^3.73.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.66.0.tgz",
+      "integrity": "sha512-K5Y9IettN9yIOnpqCs40HRLGqaGUoaQ50+ZsLqX2kPCk3TzJVpKZ9icKwaJ4Nxm72QgGVT5Ovfr/9FXbgd3b/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/profiling-node": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.66.0.tgz",
+      "integrity": "sha512-l37MXflBZPiZHKHhW/oe5PlUy9G9fQHPea/vVCf/4J4Cv82APJ58wE49qP+elkvygyUoed0surijdBnh4rZIVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.66.0",
+        "@sentry/node": "10.66.0",
+        "@sentry/node-cpu-profiler": "^2.4.2"
+      },
+      "bin": {
+        "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.66.0.tgz",
+      "integrity": "sha512-h9EM9Wz9Mc6w2Vn7Fyh6ozjy4JC2UbUvWf9Ra1HYA4KMeYqjFA5/o0oB4pg4w/TF+rb+9OF/HNqxjuczxpudpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.6.1",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@simplewebauthn/server": {
       "version": "13.3.1",
@@ -5292,9 +5611,10 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -6471,6 +6791,15 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -8107,9 +8436,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -8219,6 +8549,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -9347,9 +9686,10 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -11140,6 +11480,32 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.1.tgz",
+      "integrity": "sha512-0rymlHSFLwZ0ixx8DaQkoIyZojJPY2a0K2nEYslhKJ6jIYO/m0IcCb7iQsFPmS7WmKwISZiIrv5Icstrw/CmqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/import-in-the-middle/node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
+    "node_modules/import-in-the-middle/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -14552,6 +14918,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -14673,6 +15048,12 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -14764,6 +15145,18 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-ensure": {
@@ -17486,6 +17879,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -17971,6 +18377,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
     },
     "node_modules/semver": {
       "version": "7.6.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,8 @@
     "@graphql-tools/schema": "^10.0.16",
     "@graphql-tools/utils": "^10.7.2",
     "@mui/material": "^5.0.0",
+    "@sentry/node": "^10.66.0",
+    "@sentry/profiling-node": "^10.66.0",
     "@simplewebauthn/server": "^13.3.1",
     "@supabase/supabase-js": "^2.106.2",
     "axios": "^1.7.7",

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -62,6 +62,7 @@ The **DocuThinker Frontend** is built using **React 18** and **Material-UI** to 
 | **Google Drive import**          | [`gapi-script`](https://github.com/cohaolain/gapi-script) (Drive read-only)                                                                                                                                                                                                   |
 | **Passkeys**                     | [`@simplewebauthn/browser`](https://simplewebauthn.dev/)                                                                                                                                                                                                                      |
 | **Analytics**                    | Google Analytics + `@vercel/analytics` / `@vercel/speed-insights`                                                                                                                                                                                                             |
+| **Monitoring**                   | [`@sentry/react`](https://docs.sentry.io/platforms/javascript/guides/react/) — error monitoring, performance tracing, and session replay (initialized in `src/sentry.js`)                                                                                                      |
 
 ## Pages
 
@@ -322,7 +323,8 @@ DocuThinker-AI-App/
 │   │   │   ├── supabaseClient.js          # Browser Supabase client (REACT_APP_SUPABASE_*)
 │   │   │   └── passkeys.js                # WebAuthn (passkey) client helpers
 │   │   ├── App.js                         # Main App component
-│   │   ├── index.js                       # Entry point for the React app
+│   │   ├── index.js                       # Entry point for the React app (imports sentry.js first)
+│   │   ├── sentry.js                       # Sentry init (errors, tracing, session replay)
 │   │   ├── App.css                        # Global CSS 1
 │   │   ├── index.css                      # Global CSS 2
 │   │   ├── reportWebVitals.js             # Web Vitals reporting
@@ -478,12 +480,18 @@ REACT_APP_GOOGLE_DRIVE_CLIENT_ID=<oauth-client-id>   # Google OAuth client ID
 
 # --- Analytics (optional) ---
 REACT_APP_GOOGLE_ANALYTICS_ID=G-XXXXXX               # Google Analytics ID
+
+# --- Sentry monitoring (optional; falls back to the hosted project DSN) ---
+REACT_APP_SENTRY_DSN=https://<key>@<org>.ingest.us.sentry.io/<project>
+REACT_APP_SENTRY_ENV=production                       # Sentry environment (default: NODE_ENV)
+REACT_APP_SENTRY_RELEASE=                             # Release id, e.g. git SHA (optional)
 ```
 
 **Notes**
 
 - **Supabase vars** power the direct-to-Storage upload in `utils/supabaseClient.js`. If `REACT_APP_SUPABASE_URL` or `REACT_APP_SUPABASE_ANON_KEY` is missing, the browser client is `null` and uploads **fall back** to the through-backend path automatically — the app still works. `REACT_APP_SUPABASE_BUCKET` defaults to `docuthinker` when unset. The anon key cannot read the private bucket on its own; uploads are authorized by a short-lived signed-upload token minted by the backend.
 - **Google Drive vars** are only needed for the "Select from Google Drive" button in the upload modal. Leave them unset to use device upload only.
+- **Sentry vars** configure error monitoring, tracing, and session replay (initialized in `src/sentry.js`, imported first in `index.js`). If `REACT_APP_SENTRY_DSN` is unset, a hosted DocuThinker project DSN is used as a fallback; sample rates tighten automatically in production.
 - All variables are **public** in the shipped bundle. Keep service-role / secret keys on the backend.
 
 ## Running the App

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@react-oauth/google": "^0.12.1",
         "@react-three/drei": "^9.122.0",
         "@react-three/fiber": "^8.18.0",
+        "@sentry/react": "^10.66.0",
         "@simplewebauthn/browser": "^13.3.0",
         "@supabase/supabase-js": "^2.106.2",
         "@testing-library/jest-dom": "^5.17.0",
@@ -6098,6 +6099,112 @@
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.10.4",
       "license": "MIT"
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.66.0.tgz",
+      "integrity": "sha512-MaPoBqKvI7O3UhexSJ/KO/o6T4Tr3A+vQWLZYTos0mxd59jVKMKbbJ6LxM/0uWQ5JAO2XYC/kCMRvk6VqQ5QZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.66.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0",
+        "@sentry/feedback": "10.66.0",
+        "@sentry/replay": "10.66.0",
+        "@sentry/replay-canvas": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.66.0.tgz",
+      "integrity": "sha512-sHuALvJMMEilUz84F1ZOQuDoZ3MhjwUHWHkXcElcVMrDIlnTO7Ra0E6Kh0e8JyJaLBMk4Sy9srKSqH9zimQVTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.66.0.tgz",
+      "integrity": "sha512-9UbgSvds7bMJsP561eWmeyMLcfOmnwxtnx2QuW3yLobzP2Ob7CyJCOzP4tGzlTAGDrzShkFEZhiyuBUKiEK2oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.66.0.tgz",
+      "integrity": "sha512-fr69K76Gz7RRyfMerChdNjWIeQdFh+k21GJcmPCqk43dscUChOsLc3cYLS5cK7iZ/XiUmH9lVzf7EYL2kf2qsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.66.0.tgz",
+      "integrity": "sha512-aodV9C2NnaZBqJvaBceIIaVyMVEisO38EWtH5xL7IMbD6QSmBYsuNU7yYzRcdOj/+99FxJYRPaqwzGnIWnNTHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.66.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.66.0.tgz",
+      "integrity": "sha512-Djb4FxQa9bF8z3PoCO00Nw1u+6hma2YuI8JkMoE+F14KWRfCZKQ28sScsvk+OokbXgjtuIsxDEZj/qFGY0w01w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.66.0",
+        "@sentry/core": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.66.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.66.0.tgz",
+      "integrity": "sha512-z7fPWEIfAJMJySKXFIqXAzFpkHjp13WGMAmB9+hlHhi9+gjAO8owD9R4XTd86lBswveGwMHKvIx5lFKNVqDcow==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.66.0",
+        "@sentry/replay": "10.66.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@simplewebauthn/browser": {
       "version": "13.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@react-oauth/google": "^0.12.1",
     "@react-three/drei": "^9.122.0",
     "@react-three/fiber": "^8.18.0",
+    "@sentry/react": "^10.66.0",
     "@simplewebauthn/browser": "^13.3.0",
     "@supabase/supabase-js": "^2.106.2",
     "@testing-library/jest-dom": "^5.17.0",

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,3 +1,5 @@
+// Sentry must be initialized before anything else renders.
+import Sentry from "./sentry";
 import React from "react";
 import ReactDOM from "react-dom";
 import "./index.css";
@@ -6,7 +8,16 @@ import reportWebVitals from "./reportWebVitals";
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <Sentry.ErrorBoundary
+      fallback={
+        <p style={{ padding: "2rem", textAlign: "center" }}>
+          Something went wrong. The error has been reported and we&apos;re on
+          it.
+        </p>
+      }
+    >
+      <App />
+    </Sentry.ErrorBoundary>
   </React.StrictMode>,
   document.getElementById("root"),
 );

--- a/frontend/src/sentry.js
+++ b/frontend/src/sentry.js
@@ -1,0 +1,58 @@
+import * as Sentry from "@sentry/react";
+
+// Initialize Sentry as early as possible in the app lifecycle.
+// This module is imported first in `index.js` so `Sentry.init()` runs
+// before React renders and before any application code executes.
+//
+// Configuration is driven by environment variables (CRA exposes only
+// vars prefixed with `REACT_APP_`), with a sensible fallback DSN so the
+// integration works out of the box.
+//
+//   REACT_APP_SENTRY_DSN      - project DSN (defaults to the hosted DocuThinker project)
+//   REACT_APP_SENTRY_RELEASE  - release identifier (optional, e.g. git SHA)
+//   REACT_APP_SENTRY_ENV      - environment name (defaults to NODE_ENV)
+
+const DEFAULT_DSN =
+  "https://56b62c1af91c6fef6e066237685aa8e2@o4511764618543104.ingest.us.sentry.io/4511764642856960";
+
+const dsn = process.env.REACT_APP_SENTRY_DSN || DEFAULT_DSN;
+const environment =
+  process.env.REACT_APP_SENTRY_ENV || process.env.NODE_ENV || "development";
+const isProduction = environment === "production";
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment,
+    release: process.env.REACT_APP_SENTRY_RELEASE || undefined,
+
+    integrations: [
+      // Performance tracing (page loads + navigations).
+      Sentry.browserTracingIntegration(),
+      // Session Replay (records user sessions for debugging).
+      Sentry.replayIntegration(),
+    ],
+
+    // Performance Monitoring: sample 100% of transactions in dev, 10% in prod.
+    tracesSampleRate: isProduction ? 0.1 : 1.0,
+
+    // Connect frontend traces to the backend API for distributed tracing.
+    tracePropagationTargets: [
+      "localhost",
+      /^https:\/\/docuthinker-app-backend-api\.vercel\.app/,
+    ],
+
+    // Session Replay: record 10% of all sessions, plus 100% of sessions
+    // in which an error occurs.
+    replaysSessionSampleRate: isProduction ? 0.1 : 1.0,
+    replaysOnErrorSampleRate: 1.0,
+
+    // Structured logs -> Sentry Logs.
+    enableLogs: true,
+
+    // Attach user IP/context and request data to events.
+    sendDefaultPii: true,
+  });
+}
+
+export default Sentry;


### PR DESCRIPTION
## SUMMARY

Integrates **Sentry** end-to-end for full application observability — error monitoring, performance tracing, session replay, CPU profiling, and structured logs — across the React frontend and the Express backend.

**Frontend (`@sentry/react`)**
- New `frontend/src/sentry.js` initializes Sentry **before** React renders (imported first in `index.js`).
- Integrations: `browserTracingIntegration` (performance) + `replayIntegration` (session replay), plus `enableLogs`.
- App tree wrapped in `Sentry.ErrorBoundary` with a graceful fallback UI, so uncaught render errors are reported.
- `tracePropagationTargets` points at the backend API origin so browser transactions stitch to their backend spans (distributed tracing).

**Backend (`@sentry/node` + `@sentry/profiling-node`)**
- New `backend/instrument.js` initializes Sentry and is `require`d at the **very top** of `index.js`, before any other module, so Express/HTTP are auto-instrumented at require-time.
- `Sentry.setupExpressErrorHandler(app)` registered **after all routes** and **before** the existing global/`UnauthorizedError`/`[UNHANDLED]` error handlers.
- Tracing + profiling + logs enabled.

**Configuration** — driven by env vars with a hosted project DSN fallback, so it works out of the box:
- Frontend: `REACT_APP_SENTRY_DSN`, `REACT_APP_SENTRY_ENV`, `REACT_APP_SENTRY_RELEASE`
- Backend: `SENTRY_DSN`, `SENTRY_RELEASE`
- Sample rates tighten automatically when `NODE_ENV=production`.

**Docs**
- `README.md` — Sentry badge added to the *Monitoring & Observability* badge group; prose observability entry; env-var tables (frontend + backend).
- `ARCHITECTURE.md` — Sentry nodes wired into the frontend, backend, and production observability mermaid diagrams; prose in Frontend & Backend Architecture sections.
- `DEVOPS.md` — new *Sentry — APM* subsection framed as the app-level layer complementary to the self-hosted infra stack; stack line updated.
- `frontend/README.md` & `backend/README.md` — Tech-stack rows, feature bullets, env-var sections/examples, and file-structure entries.

## TEST PLAN

- **Frontend build passes** with the new SDK/imports: `cd frontend && npm run build` → *Compiled successfully* (bundle +162 KB gzip from the Sentry SDK, expected).
- **Backend loads & instruments**: verified `@sentry/node` exposes `init`/`setupExpressErrorHandler`, `@sentry/profiling-node` exposes `nodeProfilingIntegration`, `require('./instrument')` loads cleanly, and `node --check index.js` passes.
- **Formatting**: all changed source files pass `prettier --check`.
- **Manual verification (post-merge, optional)**: temporarily throw in any route (`throw new Error('Sentry test')`) or add a button that throws in the UI, trigger it, and confirm the event appears in the `docuthinker-app` Sentry project.

> No backend unit tests import `index.js`, so the middleware wiring is covered by load/syntax verification rather than the Jest suite. SDK version: `10.66.0` (frontend + backend).

---

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I've included tests I've run to ensure my changes work.
- [ ] I've added unit tests for any new code, if applicable. _(Sentry init is config/side-effect wiring; verified via build + load checks.)_
- [x] I've documented any added code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)