### PR TITLE
feat: rotate Google Gemini API keys with quota-aware fallback

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,7 +37,7 @@ DocuThinker is an **enterprise-grade**, full-stack AI-powered document analysis 
 - **Format-Aware Viewer**: The result screen renders each document the way it should look — native **PDF in an `<iframe>`** of a signed Supabase URL, **DOCX/HTML/CSV** as sanitized HTML, **Markdown** via `react-markdown`, **JSON/code** as monospace `<pre>`, and everything else as `pre-wrap` text
 - **Interactive Result View**: A **drag-resizable** Original | Summary split, a **text-selection action menu** (Copy / Summarize / Rewrite / Ask Chat / Search the web) that operates only on the highlighted text, and a **multi-step animated upload progress** (Reading → Storing → Analyzing → Ready) with a smooth reveal into results
 - **Scalable Per-Document Storage**: Each uploaded document is its own Firestore record in a `users/{uid}/documents/{docId}` **subcollection**, with heavy text/HTML/file payloads offloaded to **Supabase Storage**. This is the permanent fix for the previous inline-array design that hit Firestore's 1 MB-per-document ceiling (see [Document Storage & Data Model](#document-storage--data-model))
-- **AI-Powered Summarization**: Resilient summarization using **Google Gemini** (`@google/generative-ai`) with dynamic model discovery, rotation, and multi-model fallback (the production summary path). The document **title** and **today's date** are injected into every system prompt, and the summary prompt asks for easy-to-read, model-decided formatting (light Markdown). A separate Python **LangGraph + CrewAI** pipeline powers deep multi-agent analysis
+- **AI-Powered Summarization**: Resilient summarization using **Google Gemini** (`@google/generative-ai`) with dynamic model discovery, model + API-key rotation, and multi-model / multi-key fallback (the production summary path). The document **title** and **today's date** are injected into every system prompt, and the summary prompt asks for easy-to-read, model-decided formatting (light Markdown). A separate Python **LangGraph + CrewAI** pipeline powers deep multi-agent analysis
 - **Intelligent Chat**: Context-aware conversational AI for document Q&A
 - **Multi-Language Support**: Document processing and summarization in multiple languages
 - **Real-time Analytics**: User behavior tracking and document analytics
@@ -562,7 +562,7 @@ graph TB
         subgraph "Service Layer"
             O[User Service]
             P[Document Service]
-            Q[Gemini AI Service<br/>discovery + rotation + fallback]
+            Q[Gemini AI Service<br/>discovery + model/key rotation + fallback]
             R[Supabase Storage Service<br/>files + content JSON + signed URLs]
         end
 
@@ -615,7 +615,8 @@ graph TB
 > **Note on the production AI path.** The Express backend summarizes with **Google Gemini** via `@google/generative-ai` (see `services/services.js`). On each call it:
 > 1. **Discovers** available models from `GET https://generativelanguage.googleapis.com/v1/models`, keeping only models whose name contains `gemini`, **excludes** `embedding` and `pro` variants, and that advertise the `generateContent` method.
 > 2. **Caches** the discovered list for **5 minutes** (`GEMINI_MODEL_CACHE_TTL_MS`); if discovery fails it reuses the last good list or falls back to `gemini-2.5-flash` (`DEFAULT_GEMINI_MODEL_FALLBACK`).
-> 3. **Rotates** the starting model (round-robin via `geminiModelRotationIndex`) and **falls back across every model in order** — a `429`/`503`/blank error on one model transparently retries the next, and only after exhausting all of them does it surface a descriptive error (raw Gemini errors are often blank, which previously produced opaque 500s).
+> 3. **Rotates** the starting model (round-robin via `geminiModelRotationIndex`) and **falls back across every model in order** — a `503`/blank/non-quota error on one model transparently retries the next.
+> 4. **Rotates API keys** — every env var matching `GOOGLE_AI_API_KEY<n>` (`GOOGLE_AI_API_KEY`, `GOOGLE_AI_API_KEY1`, `GOOGLE_AI_API_KEY2`, …) is auto-discovered (`getGoogleAiApiKeys`), de-duplicated, and rotated round-robin (`geminiKeyRotationIndex`). Keys are the **outer** fallback loop, models the **inner** loop: when a key returns a quota/`429` error (`isGeminiQuotaError`) it is abandoned and the **next key** is tried immediately (rather than grinding every model on an exhausted key), so a single free-tier quota no longer fails the request. A descriptive error is surfaced only after **all keys × models** are exhausted (raw Gemini errors are often blank, which previously produced opaque 500s). Adding a key is an env-var change only — no code edit.
 >
 > **Prompt context injection.** Today's real date (`currentDateContext()`, formatted as a full `weekday, Month D, YYYY`) is prepended to **every** system instruction across all Gemini tasks (summary, chat, key ideas, discussion points, sentiment, bullet/translated summary, rewrite, recommendations, refine) for recency-aware reasoning. The document **title** is additionally fed to `generateSummary` as extra context (`Title: "…"` prefixed to the text), while the *stored* `originalText` is kept clean (no title prefix) so the viewer and chat stay intact. The summary prompt itself now asks for an **easy-to-read, model-decided layout** — short paragraphs with the occasional heading or short list only where it genuinely improves clarity, emitted as light Markdown — rather than a fixed structure.
 >
@@ -849,7 +850,7 @@ sequenceDiagram
     Note over FE,SB: Original bytes go straight to Supabase —<br/>bypasses Vercel's ~4.5 MB body limit
     Note over FE: Step 3 — Analyzing
     FE->>BE: POST /upload { userId, title, text, html, filePath, fileType }
-    BE->>AI: generateSummary(text, title)<br/>[date + title injected · discovery + rotation + fallback]
+    BE->>AI: generateSummary(text, title)<br/>[date + title injected · discovery + model/key rotation + fallback]
     AI-->>BE: summary
     BE->>SB: storeDocumentContent(uid, docId, { originalText, originalHtml })
     SB-->>BE: contentPath

--- a/README.md
+++ b/README.md
@@ -909,6 +909,7 @@ The backend and frontend each read from their own `.env` file (both git-ignored)
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `FIREBASE_*`                | Firebase Admin service-account credentials (`FIREBASE_PROJECT_ID`, `FIREBASE_PRIVATE_KEY`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_DATABASE_URL`, …) for Auth + Firestore. |
 | `GOOGLE_AI_API_KEY`         | Google Gemini API key (model list, generation, audio).                                                                                                                |
+| `GOOGLE_AI_API_KEY1`, `GOOGLE_AI_API_KEY2`, … | Optional extra Gemini keys — auto-discovered and rotated so a request fails over to the next key on a quota/`429`. Add as many `GOOGLE_AI_API_KEY<n>` as needed.       |
 | `AI_INSTRUCTIONS`           | Base system-prompt text prepended to every AI request.                                                                                                                |
 | `SUPABASE_URL`              | Supabase project URL.                                                                                                                                                 |
 | `SUPABASE_SERVICE_ROLE_KEY` | Server-side Supabase key for signing upload/download URLs and storing content (never exposed to the browser).                                                         |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **DocuThinker - AI-Powered Document Analysis and Summarization App**
 
-Welcome to **DocuThinker**! This is a full-stack application that integrates an AI-powered document processing backend, blue/green & canary deployment on an AWS infrastructure, and a React-based frontend. The app allows users to upload documents for summarization, generate key insights, chat with an AI, and do even more with the document's content.
+Welcome to **DocuThinker**! This is a full-stack application that integrates an AI-powered document processing backend, blue/green & canary deployment on an AWS infrastructure, and a React-based frontend. The app allows users to upload documents for summarization, generate key insights, chat with an AI, and do even more with the document's content. 🚀
 
 <p align="center">
   <a href="https://docuthinker.vercel.app" style="cursor: pointer">

--- a/backend/README.md
+++ b/backend/README.md
@@ -37,7 +37,7 @@ The backend is deployed as a **Vercel serverless function** (the whole Express a
 | HTTP server | **Express** (`express`), deployed on **Vercel** as a serverless function |
 | Auth & user store | **Firebase Admin SDK** — Firebase Authentication + Cloud Firestore |
 | File & content storage | **Supabase Storage** (`@supabase/supabase-js`, private bucket, `service_role` key, server-side only) |
-| AI / LLM | **Google Gemini** (`@google/generative-ai`) with dynamic model discovery, rotation, and multi-model fallback |
+| AI / LLM | **Google Gemini** (`@google/generative-ai`) with dynamic model discovery, model rotation, multi-model fallback, and multi-key rotation |
 | Caching | **Redis** (`redis`) — session, document metadata, query results, recently-viewed lists |
 | GraphQL | **`express-graphql`** + **`@graphql-tools/schema`**, with the **GraphiQL** explorer at `/graphql` |
 | API docs | **Swagger / OpenAPI** (`swagger-jsdoc`), served via Swagger UI at `/api-docs` |
@@ -120,7 +120,8 @@ Create a `.env` file in the `backend` directory (or the repo root). The backend 
 
 | Variable | Description |
 | -------- | ----------- |
-| `GOOGLE_AI_API_KEY` | API key for Google Generative AI (Gemini). Required for all AI endpoints and audio processing. |
+| `GOOGLE_AI_API_KEY` | Primary API key for Google Generative AI (Gemini). Required for all AI endpoints and audio processing. |
+| `GOOGLE_AI_API_KEY1`, `GOOGLE_AI_API_KEY2`, … | **Optional** additional Gemini keys for automatic rotation/fallback. Any `GOOGLE_AI_API_KEY<n>` var is picked up automatically (add as many as you like); when one key hits a quota/`429`, the next is tried. |
 | `AI_INSTRUCTIONS` | Base system-prompt text prepended to every AI instruction (sets the assistant's persona/rules). |
 
 ### Supabase Storage
@@ -173,6 +174,9 @@ FIREBASE_DATABASE_URL=https://your-project-id.firebaseio.com
 
 # Google Gemini
 GOOGLE_AI_API_KEY=your-google-generative-ai-api-key
+# Optional extra keys for rotation/fallback on quota (429). Add as many as needed.
+GOOGLE_AI_API_KEY1=your-second-gemini-key
+GOOGLE_AI_API_KEY2=your-third-gemini-key
 AI_INSTRUCTIONS="You are DocuThinker, a helpful document assistant..."
 
 # Supabase Storage
@@ -362,7 +366,8 @@ All AI features use **Google Gemini** via `@google/generative-ai`, wrapped in a 
 
 - **Dynamic model discovery** — the live model list is fetched from the Generative Language API (`/v1/models`), filtered to text-capable Gemini models (excludes embedding/pro variants), and cached for 5 minutes. Falls back to `gemini-2.5-flash` if discovery fails.
 - **Rotation** — requests rotate the starting model across the discovered list to spread load.
-- **Multi-model fallback** — each request tries models in turn; if one fails (e.g. `429`/`503`/quota), it transparently retries the next, surfacing a meaningful error only after **all** models are exhausted.
+- **Multi-key fallback (API key rotation)** — multiple Gemini API keys can be configured (`GOOGLE_AI_API_KEY`, `GOOGLE_AI_API_KEY1`, `GOOGLE_AI_API_KEY2`, …). Keys are discovered automatically from the environment (any `GOOGLE_AI_API_KEY<n>` var — no code change to add more), rotated round-robin across requests, and tried in turn. When a key returns a quota/`429` error it is skipped and the **next key** is tried immediately, so a single exhausted free-tier quota no longer fails the request. A request succeeds on the first working key+model and only errors after **all keys** are exhausted.
+- **Multi-model fallback** — for each key, the request tries models in turn; if one fails (e.g. `503` or a non-quota error), it transparently retries the next model, surfacing a meaningful error only after all models (across all keys) are exhausted.
 - **Context injection** — every AI system prompt (for **all** generations, not just summaries) is prefixed with today's real date (`currentDateContext`), and for `/upload` the document `title` is prepended to the text fed to the model so it can reason about recency and subject matter. The `title` is used only as AI context — the stored/returned `originalText` stays clean (no title prefix).
 - **Readable summary formatting** — the `/upload` summary prompt asks Gemini to produce an easy-to-read, **model-decided** layout: clear plain language with short paragraphs, using a brief heading or short list **only where it genuinely improves clarity** (it explicitly avoids forced bullet-heavy or dense output). The summary is rendered as Markdown, so light Markdown (short headings, occasional bold/lists) is allowed.
 

--- a/backend/services/services.js
+++ b/backend/services/services.js
@@ -189,13 +189,71 @@ let geminiModelCache = {
   models: [],
 };
 let geminiModelRotationIndex = 0;
+let geminiKeyRotationIndex = 0;
 
+// Discover every configured Gemini API key. Any env var matching
+// `GOOGLE_AI_API_KEY` or `GOOGLE_AI_API_KEY<n>` (e.g. GOOGLE_AI_API_KEY1,
+// GOOGLE_AI_API_KEY2, ...) is picked up automatically, so adding another key is
+// purely an env-var change — no code edit required. Keys are ordered with the
+// base key first, then numerically, and de-duplicated by value.
+const getGoogleAiApiKeys = () => {
+  const keys = Object.keys(process.env)
+    .filter((name) => /^GOOGLE_AI_API_KEY\d*$/.test(name))
+    .map((name) => ({
+      name,
+      // Base key (no suffix) sorts first; suffixed keys sort by their number.
+      order:
+        name === "GOOGLE_AI_API_KEY"
+          ? 0
+          : Number(name.slice("GOOGLE_AI_API_KEY".length)),
+      value: (process.env[name] || "").trim(),
+    }))
+    .filter((entry) => entry.value.length > 0)
+    .sort((a, b) => a.order - b.order);
+
+  const seen = new Set();
+  const unique = [];
+  for (const entry of keys) {
+    if (!seen.has(entry.value)) {
+      seen.add(entry.value);
+      unique.push(entry.value);
+    }
+  }
+  return unique;
+};
+
+// First configured key. Used for non-rotated call sites (model discovery, file
+// manager) that only need a single valid key.
 const getGoogleAiApiKey = () => {
-  const apiKey = process.env.GOOGLE_AI_API_KEY;
-  if (!apiKey) {
+  const keys = getGoogleAiApiKeys();
+  if (keys.length === 0) {
     throw new Error("GOOGLE_AI_API_KEY is not configured.");
   }
-  return apiKey;
+  return keys[0];
+};
+
+// Round-robin the key order across requests so load spreads over all keys
+// instead of always hammering (and exhausting) the first one.
+const rotateGeminiKeys = (keys) => {
+  if (!Array.isArray(keys) || keys.length <= 1) {
+    return Array.isArray(keys) ? keys.slice() : [];
+  }
+  const startIndex = geminiKeyRotationIndex % keys.length;
+  geminiKeyRotationIndex = (startIndex + 1) % keys.length;
+  return keys.slice(startIndex).concat(keys.slice(0, startIndex));
+};
+
+// A 429 / quota / rate-limit failure is the signal that this *key* is
+// exhausted, so we should jump to the next key rather than grinding every model
+// on a key that has no quota left.
+const isGeminiQuotaError = (error) => {
+  const message = (error && (error.message || String(error))) || "";
+  return (
+    /\b429\b/.test(message) ||
+    /too many requests/i.test(message) ||
+    /quota/i.test(message) ||
+    /rate limit/i.test(message)
+  );
 };
 
 const normalizeGeminiModelName = (name) => name.replace(/^models\//, "");
@@ -299,31 +357,56 @@ const withGeminiModelFallback = async (label, handler) => {
     throw new Error("No Gemini models available to handle the request.");
   }
 
+  const keys = rotateGeminiKeys(getGoogleAiApiKeys());
+  if (keys.length === 0) {
+    throw new Error("GOOGLE_AI_API_KEY is not configured.");
+  }
+
+  // Try each API key in turn (outer loop) and, for each key, fall back across
+  // the available models (inner loop). Return on the first success. When a key
+  // hits a quota / 429 error we jump straight to the next key instead of
+  // grinding every model on an exhausted key — except on the last key, where we
+  // still try every model as a final fallback.
   let lastError = null;
-  for (const modelName of models) {
-    try {
-      return await handler(modelName);
-    } catch (error) {
-      lastError = error;
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      console.warn(
-        `[Gemini] ${label} failed on ${modelName}: ${errorMessage}`,
-        error && error.stack ? `\n${error.stack}` : "",
-      );
+  let attempts = 0;
+  for (let keyIndex = 0; keyIndex < keys.length; keyIndex += 1) {
+    const apiKey = keys[keyIndex];
+    const isLastKey = keyIndex === keys.length - 1;
+
+    for (const modelName of models) {
+      attempts += 1;
+      try {
+        return await handler(modelName, apiKey);
+      } catch (error) {
+        lastError = error;
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        console.warn(
+          `[Gemini] ${label} failed on ${modelName} (key ${keyIndex + 1}/${keys.length}): ${errorMessage}`,
+          error && error.stack ? `\n${error.stack}` : "",
+        );
+
+        // Exhausted key → skip its remaining models and try the next key.
+        if (isGeminiQuotaError(error) && !isLastKey) {
+          break;
+        }
+      }
     }
   }
 
-  // All models failed — surface a meaningful message (raw Gemini errors are
+  // Everything failed — surface a meaningful message (raw Gemini errors are
   // often blank, which is why the client saw a 500 with no detail).
   const lastMsg =
     lastError instanceof Error ? lastError.message : String(lastError);
-  console.error(`[Gemini] ${label} exhausted all ${models.length} model(s).`, {
-    lastMessage: lastMsg,
-    stack: lastError && lastError.stack,
-  });
+  console.error(
+    `[Gemini] ${label} exhausted ${attempts} attempt(s) across ${keys.length} key(s) and ${models.length} model(s).`,
+    {
+      lastMessage: lastMsg,
+      stack: lastError && lastError.stack,
+    },
+  );
   throw new Error(
-    `Gemini failed for "${label}" after trying ${models.length} model(s): ${
+    `Gemini failed for "${label}" after ${attempts} attempt(s) across ${keys.length} key(s) and ${models.length} model(s): ${
       lastMsg || "unknown error (likely rate limit or quota)"
     }`,
   );
@@ -346,8 +429,8 @@ const runGeminiChat = async ({
   message,
   errorMessage,
 }) => {
-  return withGeminiModelFallback(label, async (modelName) => {
-    const genAI = new GoogleGenerativeAI(getGoogleAiApiKey());
+  return withGeminiModelFallback(label, async (modelName, apiKey) => {
+    const genAI = new GoogleGenerativeAI(apiKey);
     const modelOptions = { model: modelName };
     if (systemInstruction) {
       modelOptions.systemInstruction = `${currentDateContext()} ${systemInstruction}`;
@@ -366,8 +449,8 @@ const runGeminiContent = async ({
   prompt,
   errorMessage,
 }) => {
-  return withGeminiModelFallback(label, async (modelName) => {
-    const genAI = new GoogleGenerativeAI(getGoogleAiApiKey());
+  return withGeminiModelFallback(label, async (modelName, apiKey) => {
+    const genAI = new GoogleGenerativeAI(apiKey);
     const finalModelOptions = { model: modelName, ...modelOptions };
     if (finalModelOptions.systemInstruction) {
       finalModelOptions.systemInstruction = `${currentDateContext()} ${finalModelOptions.systemInstruction}`;
@@ -444,7 +527,7 @@ exports.processAudio = async (file, context) => {
     );
   }
 
-  const fileManager = new GoogleAIFileManager(process.env.GOOGLE_AI_API_KEY);
+  const fileManager = new GoogleAIFileManager(getGoogleAiApiKey());
 
   // Upload file to Gemini
   const uploadResult = await fileManager.uploadFile(file.filepath, {


### PR DESCRIPTION
## SUMMARY

**Problem.** The backend uses a single Gemini API key. Gemini's free-tier quota (`generate_content_free_tier_input_token_count`, 250k tokens/min per project) is shared across models, so once it's hit, **every** model returns `429` and `/upload` fails with a 500 — exactly the log below:

```
[Gemini] generateSummary failed on gemini-2.5-flash: [429 Too Many Requests] ... quota ...
... (all 11 models 429) ...
[Gemini] generateSummary exhausted all 11 model(s).
[RES] POST /upload -> 500
```

**Fix.** Add **multi-key rotation** on top of the existing multi-model fallback, in `backend/services/services.js`:

- **Auto-discovery** — `getGoogleAiApiKeys()` picks up every env var matching `GOOGLE_AI_API_KEY<n>` (`GOOGLE_AI_API_KEY`, `GOOGLE_AI_API_KEY1`, `GOOGLE_AI_API_KEY2`, …), ordered base-first then numerically, de-duplicated by value. **Adding a key is an env-var change only — no code edit** (supports your planned 5 keys and any future ones).
- **Round-robin** — `rotateGeminiKeys()` rotates the starting key across requests (via `geminiKeyRotationIndex`) so load spreads instead of always exhausting key #1.
- **Quota-aware fallback** — `withGeminiModelFallback` now loops **keys (outer) × models (inner)**. Returns on the first success. When a key hits a quota/`429` (`isGeminiQuotaError`), it's abandoned and the **next key** is tried immediately — no grinding all 11 models on a key with zero quota left. The **last** key still tries all models as a final fallback. A descriptive error is surfaced only after **all keys × models** are exhausted.
- Handlers now receive the rotated `apiKey`; single-key call sites (model discovery, audio `FileManager`) use the first key via `getGoogleAiApiKey()`.

Fully backward compatible: with only `GOOGLE_AI_API_KEY` set, behavior is identical to before (one key, model fallback).

### Config

Add keys via env (local `.env` and Vercel), no code change:

```bash
GOOGLE_AI_API_KEY=key0
GOOGLE_AI_API_KEY1=key1
GOOGLE_AI_API_KEY2=key2
GOOGLE_AI_API_KEY3=key3
GOOGLE_AI_API_KEY4=key4
```

## TEST PLAN

- **Unit logic** (discovery order, dedupe, back-compat single/none, whitespace-trim, round-robin rotation incl. wrap, quota detection from the real 429 message + negative 400/500) — verified with a standalone replica of the three new pure functions: **16/16 passed**.
- **Regression** — `npx jest __tests__/uploadDocument.test.js` → **3/3 passed** (the summary path still works; the test mocks the services module).
- **Syntax + format** — `node --check services/services.js` passes; `prettier --check` clean.
- **Manual (post-deploy)** — set 2+ keys where key #1 is quota-exhausted, upload a large doc, and confirm the request succeeds on a later key and the logs show `failed on <model> (key 1/N)` → success on key 2.

> No new dependencies. Change is isolated to `backend/services/services.js` + docs.

---

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving.
  - [x] How this problem was solved.
  - [x] How reviewers can test my changes.
- [x] I've included tests I've run to ensure my changes work.
- [ ] I've added unit tests for any new code, if applicable. _(Verified via standalone logic tests + existing suite; the new functions are module-private and not exported for direct import.)_
- [x] I've documented any added code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)